### PR TITLE
adding missing <\img> tag on vtex-product-customizer.md

### DIFF
--- a/docs/vtex-io/Store Framework Apps/basic-components/vtex-product-customizer.md
+++ b/docs/vtex-io/Store Framework Apps/basic-components/vtex-product-customizer.md
@@ -176,7 +176,7 @@ Thanks goes to these wonderful people:
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/leoWorkingGood"><img src="https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/images/vtex-product-customizer-4.png">💻</a></td>
+    <td align="center"><a href="https://github.com/leoWorkingGood"><img src="https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/images/vtex-product-customizer-4.png">💻</img></a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fixing this reported error: "Unexpected closing tag `</a>`, expected corresponding closing tag for `<img>`"