### PR TITLE
adding missing <\img> tag on vtex-category-menu.md

### DIFF
--- a/docs/vtex-io/Store Framework Apps/advanced-components/vtex-category-menu.md
+++ b/docs/vtex-io/Store Framework Apps/advanced-components/vtex-category-menu.md
@@ -95,7 +95,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/khrizzcristian"><img src="https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/images/vtex-category-menu-0.png">💻</img></a></td>
+    <td align="center"><a href="https://github.com/khrizzcristian"><img src="https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/images/vtex-category-menu-0.png"></img></a></td>
   </tr>
 </table>
 

--- a/docs/vtex-io/Store Framework Apps/advanced-components/vtex-category-menu.md
+++ b/docs/vtex-io/Store Framework Apps/advanced-components/vtex-category-menu.md
@@ -95,7 +95,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/khrizzcristian"><img src="https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/images/vtex-category-menu-0.png">💻</a></td>
+    <td align="center"><a href="https://github.com/khrizzcristian"><img src="https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/images/vtex-category-menu-0.png">💻</img></a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fixing this reported error: "Unexpected closing tag `</a>`, expected corresponding closing tag for `<img>`"