### PR TITLE
fix: ⚒️ fix the tab-layout block declaration

### DIFF
--- a/docs/vtex-io/Store Framework Apps/layout-apps/vtex-tab-layout.md
+++ b/docs/vtex-io/Store Framework Apps/layout-apps/vtex-tab-layout.md
@@ -41,7 +41,7 @@ Now, you are able to use all the blocks exported by the `tab-layou` app. Check o
 ```json
 "store.home": {
   "blocks": [
-    "tab-layout#home
+    "tab-layout#home"
   ]
 },
 ```
@@ -51,7 +51,7 @@ Now, you are able to use all the blocks exported by the `tab-layou` app. Check o
 ```diff
   "store.home": {
     "blocks": [
-      "tab-layout#home
+      "tab-layout#home"
     ]
   },
 + "tab-layout#home": 
@@ -71,7 +71,7 @@ Now, you are able to use all the blocks exported by the `tab-layou` app. Check o
 ```diff
   "store.home": {
     "blocks": [
-      "tab-layout#home
+      "tab-layout#home"
     ]
   },
   "tab-layout#home": 
@@ -110,7 +110,7 @@ Now, you are able to use all the blocks exported by the `tab-layou` app. Check o
 ```diff
   "store.home": {
     "blocks": [
-      "tab-layout#home
+      "tab-layout#home"
     ]
   },
   "tab-layout#home": 


### PR DESCRIPTION
I added a quotation mark at the close of the tab-layout declaration.