### PR TITLE
Move Buyer Organizations API overview

### DIFF
--- a/docs/guides/Buyer Organizations/buyer-organizations-api-overview.md
+++ b/docs/guides/Buyer Organizations/buyer-organizations-api-overview.md
@@ -5,6 +5,7 @@ hidden: true
 createdAt: "2021-10-08T17:53:09.698Z"
 updatedAt: "2022-05-10T14:52:20.752Z"
 ---
+
 The Buyer Organizations API allows you to manage Buyer Organizations and their associated users.
 
 ## Index


### PR DESCRIPTION
This PR moves the Buyer Organizations API overview.md file that was previously in the [/readme-api-md](https://github.com/vtexdocs/dev-portal-content/tree/main/readme-api-md) folder, to a new folder in [/docs/guides](https://github.com/vtexdocs/dev-portal-content/tree/main/docs/guides).
