### PR TITLE
Update ssltls-security-protocols-and-ciphers-at-checkout.md

### DIFF
--- a/docs/guides/Checkout/security/ssltls-security-protocols-and-ciphers-at-checkout.md
+++ b/docs/guides/Checkout/security/ssltls-security-protocols-and-ciphers-at-checkout.md
@@ -7,13 +7,15 @@ updatedAt: "2022-08-16T18:08:37.001Z"
 ---
 VTEX performs integrations with external vendors through secure HTTPS connections, using the TLS 1.2 protocol.
 
-For services performed in the Checkout module, where there is an exchange of data with sellers that are not part of VTEX (external fulfillment), the following ciphers are supported for the external seller, so that the flow of information occurs correctly.
 [block:callout]
 {
   "type": "warning",
   "body": "TLS 1.0 and 1.1 integration protocols are not supported by VTEX."
 }
 [/block]
+
+For services performed in the Checkout module, where there is an exchange of data with sellers that are not part of VTEX (external fulfillment), the following ciphers are supported for the external seller, so that the flow of information occurs correctly.
+
 | Cipher Suite Name (IANA)      | Name (OpenSSL)      |
 | ---------- | ---------- |
 |   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384  |   ECDHE-RSA-AES256-SHA384    |


### PR DESCRIPTION
Atualmente, a [tabela com as cifras suportadas](https://developers.vtex.com/docs/guides/ssltls-security-protocols-and-ciphers-at-checkout) está quebrada:
![image](https://user-images.githubusercontent.com/999677/211036304-33d21095-d430-408f-b18e-3ec87cad5e6a.png)

Também movi o alerta sobre protocolos não suportados para junto da informação sobre qual protocolo (TLS 1.2) é suportado.