### PR TITLE
fix(pixel-apps): Fix a variable in the code example

### DIFF
--- a/docs/vtex-io/Store-Framework-Apps/pixel-apps/setting-up-lazy-load-for-pixel-apps.md
+++ b/docs/vtex-io/Store-Framework-Apps/pixel-apps/setting-up-lazy-load-for-pixel-apps.md
@@ -41,7 +41,7 @@ vtex settings set vtex.store experimentalLazyLoadAllPixels true
 
 To make the pixel app load itself lazily, you must add the `experimentalLazyLoad` property on the app [settingsSchema](https://developers.vtex.com/docs/guides/vtex-io-documentation-4-configuringyourappsettings). By doing this, the `vtex.pixel-server` app will create a local setting `experimentalHasOwnLazyLoad` with value `true`.
 
-> :warning: Do not add the `experimentalHasOwnLazyLoad` setting on the app `settingsSchema`, nor set it via VTEX IO CLI. This is an internal setting.
+> ⚠️ Do not add the `experimentalHasOwnLazyLoad` setting on the app `settingsSchema`, nor set it via VTEX IO CLI. This is an internal setting.
 
 The pixel app can access the `experimentalLazyLoad` [setting](https://developers.vtex.com/docs/guides/vtex-io-documentation-4-configuringyourappsettings) like in this code example:
 
@@ -57,7 +57,7 @@ Example of how to do the lazy load:
 
   function whatShouldBeLazyLoadHere() { ... }
 
-  if (isLazyLoad) {
+  if (experimentalLazyLoad) {
     function lazyTimeout() {
       setTimeout(whatShouldBeLazyLoadHere, 5000)
       window.removeEventListener('load', lazyTimeout)


### PR DESCRIPTION
I was reading this page when I noticed the variable `isLazyLoad` wasn't defined anywhere, and it made sense for it to be the existing `experimentalLazyLoad` defined above.

Also noticed this `:warning` and tried to fix it.
<img width="320" alt="CleanShot 2023-02-03 at 09 56 44@2x" src="https://user-images.githubusercontent.com/381395/216609005-be5e8bfb-2d7a-472f-a7d4-5b3b228324c2.png">

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
