### PR TITLE
Fixed empty callout

### DIFF
--- a/docs/vtex-io/Store-Framework-Apps/basic-components/vtex-product-summary-productsummarylist.md
+++ b/docs/vtex-io/Store-Framework-Apps/basic-components/vtex-product-summary-productsummarylist.md
@@ -71,6 +71,4 @@ For `PreferredSKUEnum`:
 | Cheapest        | `PRICE_ASC`       | Selects the cheapest SKU in stock it finds.        |
 | Most Expensive  | `PRICE_DESC`      | Selects the most expensive SKU in stock it finds.  |
 
-> ⚠️ 
->
-> To select which SKU will take preference over this prop, create a Product (field) specification and assign the value of the desired SKU to be initially set for each product. If the specification doesn't exist or the value is empty, the `preferredSKU` prop will be used as a fallback. For more information, please refer to [this guide](https://developers.vtex.com/docs/guides/vtex-io-documentation-configuring-custom-images-for-the-sku-selector).
+> ⚠️ To select which SKU will take preference over this prop, create a Product (field) specification and assign the value of the desired SKU to be initially set for each product. If the specification doesn't exist or the value is empty, the `preferredSKU` prop will be used as a fallback. For more information, please refer to [this guide](https://developers.vtex.com/docs/guides/vtex-io-documentation-configuring-custom-images-for-the-sku-selector).


### PR DESCRIPTION
Looks like our Markdown renderer doesn't like new lines:

https://developers.vtex.com/docs/guides/vtex-product-summary-productsummarylist

![Screen Shot 2023-02-15 at 10 42 11](https://user-images.githubusercontent.com/2094877/219043545-d14a956d-4212-4a42-85f9-fef8bb2fdbe9.png)

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
