### PR TITLE
Update vtex-io-documentation-migrating-storefront-from-legacy-to-io.md

### DIFF
--- a/docs/vtex-io/Storefront-Guides/vtex-io-documentation-going-live/vtex-io-documentation-migrating-storefront-from-legacy-to-io.md
+++ b/docs/vtex-io/Storefront-Guides/vtex-io-documentation-going-live/vtex-io-documentation-migrating-storefront-from-legacy-to-io.md
@@ -37,7 +37,7 @@ Once you have created your workspaces, [open a support ticket](https://help.vtex
 
 You can check the Edition app installed in a workspace by running the following command: `vtex edition get`. Please refer to [Edition apps](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) for further information.
 
->⚠️ Do not request the Edition change for the master workspace of your store. This will make your main domain display a blank Store Framework template instead of your existing Legacy CMS Portal store.
+>⚠️ Do not request the Edition change for the master workspace of your store. This will cause some features, such as My Account, to stop functioning properly.
 
 ### Step 2 - Developing and testing your storefront
 


### PR DESCRIPTION
Fixing warning according to feedback in [EDU-8614](https://vtex-dev.atlassian.net/browse/EDU-8614).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)


[EDU-8614]: https://vtex-dev.atlassian.net/browse/EDU-8614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ