### PR TITLE
Update sending-emails-with-triggers-in-master-data-v2.md

### DIFF
--- a/docs/guides/Master-Data/guides/sending-emails-with-triggers-in-master-data-v2.md
+++ b/docs/guides/Master-Data/guides/sending-emails-with-triggers-in-master-data-v2.md
@@ -5,16 +5,19 @@ hidden: false
 createdAt: "2022-08-03T14:48:49.642Z"
 updatedAt: "2022-08-03T14:56:02.147Z"
 ---
-You can use Master Data v2 triggers to automatically send emails to your customers.
-[block:callout]
-{
-  "type": "info",
-  "body": "You can find more information about creating triggers in the article [Setting up triggers in Master Data v2](https://developers.vtex.com/vtex-rest-api/docs/setting-up-triggers-in-master-data-v2)."
-}
-[/block]
 
+There are two ways of sending emails automatically with Master Data v2 triggers:
 
-## Properties
+- [Sending emails](#sending-emails)
+- [Sending emails using Message Center templates](#send-email-using-message-center-template)
+
+>ℹ️ Learn more about triggers in the article [Setting up triggers in Master Data v2](https://developers.vtex.com/docs/guides/setting-up-triggers-in-master-data-v2).
+
+## Sending emails
+
+This is the more direct method of sending emails with Master Data v2 triggers, but without the standardization provided by [Message Center templates](#send-email-using-message-center-template).
+
+### Properties
 
 | Field     | Description     |
 | ---------- | ---------- |
@@ -27,13 +30,11 @@ You can use Master Data v2 triggers to automatically send emails to your custome
 | body*       | the message body |
 | bcc       | address collection that contains the blind carbon copy (BCC) |
 
-\* Required
-
-## Dynamic expressions
+### Dynamic expressions
 
 You can use dynamic expressions to deal with document properties in these settings. For more information, look at the [Article on dynamic expressions](https://developers.vtex.com/vtex-rest-api/docs/adding-document-field-values-with-dynamic-expressions).
 
-## JSON Schema example:
+### JSON Schema example
 
 ```json
     {
@@ -52,6 +53,58 @@ You can use dynamic expressions to deal with document properties in these settin
           "replyTo": "noreply@email.com",
           "body": "VTEX Master Data Triggers email body"
         } 
+      ]
+    }
+```
+
+## Sending emails using Message Center templates
+
+See below how to set up a trigger to send emails using a [Message Center](https://help.vtex.com/pt/tutorial/conhecendo-o-message-center--tutorials_84) template.
+
+### Properties
+
+| Field     | Description     |
+| ---------- | ---------- |
+| type*       | The action type must be `t-email` |
+| template*       | Name of the Message Center template |
+| provider*       | Message Center provider name (usually named as `default`) |
+| from*       | define name and email of from address |
+| to*       | list of emails that email will be sended |
+| replyTo*       | list of addresses to reply |
+| subject*       | subject line for this e-mail |
+| body*       | the message body |
+| bcc       | address collection that contains the blind carbon copy (BCC) |
+
+### JSON Schema example
+
+```json
+    {
+      "properties": { ... },
+      "v-triggers" [
+            {
+            "type": "t-email",
+            "template": "template-name",
+            "provider": "default",
+            "subject": "My template email with VTEX Master Data",
+            "to": [
+                "{!email}",
+                "test@email.com"
+            ],
+            "bcc": [
+                "myemail@test.com"
+            ],
+            "replyTo": "noreply@company.com",
+            "body": {
+                        "firstName": "{firstName}",
+                        "email": "{email}",
+                        "id": "{!id}",
+                        "clientName": "{!clientProfileData.firstName{!clientProfileData.lastName}",
+                        "ownerListName": "{!customData.customApps[0fields.ownerListName}",
+                        "ownerListEmail": "{!customData.customApps[0fields.ownerListEmail}",
+                        "items": "{!items}",
+                        "openTextField": "{!openTextField.value}"
+                    }
+        }
       ]
     }
 ```

--- a/docs/guides/Master-Data/guides/sending-emails-with-triggers-in-master-data-v2.md
+++ b/docs/guides/Master-Data/guides/sending-emails-with-triggers-in-master-data-v2.md
@@ -9,13 +9,13 @@ updatedAt: "2022-08-03T14:56:02.147Z"
 There are two ways of sending emails automatically with Master Data v2 triggers:
 
 - [Sending emails](#sending-emails)
-- [Sending emails using Message Center templates](#send-email-using-message-center-templates)
+- [Sending emails using Message Center templates](#sending-emails-using-message-center-templates)
 
 >ℹ️ Learn more about triggers in the article [Setting up triggers in Master Data v2](https://developers.vtex.com/docs/guides/setting-up-triggers-in-master-data-v2).
 
 ## Sending emails
 
-This is the more direct method of sending emails with Master Data v2 triggers, but without the standardization provided by [Message Center templates](#send-email-using-message-center-templates).
+This is the more direct method of sending emails with Master Data v2 triggers, but without the standardization provided by [Message Center templates](#sending-emails-using-message-center-templates).
 
 ### Properties
 

--- a/docs/guides/Master-Data/guides/sending-emails-with-triggers-in-master-data-v2.md
+++ b/docs/guides/Master-Data/guides/sending-emails-with-triggers-in-master-data-v2.md
@@ -9,26 +9,26 @@ updatedAt: "2022-08-03T14:56:02.147Z"
 There are two ways of sending emails automatically with Master Data v2 triggers:
 
 - [Sending emails](#sending-emails)
-- [Sending emails using Message Center templates](#send-email-using-message-center-template)
+- [Sending emails using Message Center templates](#send-email-using-message-center-templates)
 
 >ℹ️ Learn more about triggers in the article [Setting up triggers in Master Data v2](https://developers.vtex.com/docs/guides/setting-up-triggers-in-master-data-v2).
 
 ## Sending emails
 
-This is the more direct method of sending emails with Master Data v2 triggers, but without the standardization provided by [Message Center templates](#send-email-using-message-center-template).
+This is the more direct method of sending emails with Master Data v2 triggers, but without the standardization provided by [Message Center templates](#send-email-using-message-center-templates).
 
 ### Properties
 
-| Field     | Description     |
-| ---------- | ---------- |
-| type*       | The action type must be `email` |
-| provider*       | Message Center provider name (usually named as `default`) |
-| from*       | define name and email of from address |
-| to*       | list of emails that email will be sended |
-| replyTo*       | list of addresses to reply |
-| subject*       | subject line for this e-mail |
-| body*       | the message body |
-| bcc       | address collection that contains the blind carbon copy (BCC) |
+| Field     | Type     | Description     |
+| ---------- | ---------- | ---------- |
+| type*       | String | The action type must be `email` |
+| provider*       | String | Message Center provider name (usually named as `default`) |
+| from*       | Object | Name and email address of sender |
+| to*       | Array | List of emails that email will be sended |
+| replyTo*       | Array | Email address for replies |
+| subject*       | String | Email subject |
+| body*       | String | Email message body |
+| bcc       | Array | List of email addresses that will receive a blind carbon copy (BCC) of the message |
 
 ### Dynamic expressions
 
@@ -59,21 +59,21 @@ You can use dynamic expressions to deal with document properties in these settin
 
 ## Sending emails using Message Center templates
 
-See below how to set up a trigger to send emails using a [Message Center](https://help.vtex.com/pt/tutorial/conhecendo-o-message-center--tutorials_84) template.
+See below how to set up a trigger to send emails using a [Message Center](https://help.vtex.com/en/tutorial/understanding-the-message-center--tutorials_84) template.
 
 ### Properties
 
-| Field     | Description     |
-| ---------- | ---------- |
-| type*       | The action type must be `t-email` |
-| template*       | Name of the Message Center template |
-| provider*       | Message Center provider name (usually named as `default`) |
-| from*       | define name and email of from address |
-| to*       | list of emails that email will be sended |
-| replyTo*       | list of addresses to reply |
-| subject*       | subject line for this e-mail |
-| body*       | the message body |
-| bcc       | address collection that contains the blind carbon copy (BCC) |
+| Field     | Type | Description     |
+| ---------- | ---------- | ---------- |
+| type*       | String | The action type must be `t-email` |
+| template*       | String | Name of the Message Center template |
+| provider*       | String | Message Center provider name (usually named as `default`) |
+| from       | Object | Name and email address of sender |
+| to*       | Array | List of email addresses to send the email |
+| replyTo*       | String | Email address for replies |
+| subject*       | String | Email subject |
+| body*       | String | Email message body |
+| bcc       | Array | List of email addresses that will receive a blind carbon copy (BCC) of the message |
 
 ### JSON Schema example
 


### PR DESCRIPTION
Adding the option of sending emails using Message Center templates to [email trigger tutorial](https://developers.vtex.com/docs/guides/sending-emails-with-triggers-in-master-data-v2).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
