### PR TITLE
Update master-data-v2-orders-entity-deprecation.md

### DIFF
--- a/docs/release-notes/master-data-v2-orders-entity-deprecation.md
+++ b/docs/release-notes/master-data-v2-orders-entity-deprecation.md
@@ -2,6 +2,7 @@
 title: "Master Data v2 orders entity deprecation"
 slug: "master-data-v2-orders-entity-deprecation"
 hidden: false
+createdAt: 2023-04-11T09:18:00.000Z
 type: "deprecated"
 excerpt: "VTEX will deprecate the order entity of Master Data v2 in October 2023. Learn how to adapt your store integrations."
 ---


### PR DESCRIPTION
I think my release note is not being displayed correctly because it does not have a `creationDate`. Trying to add the date to see if that solves it.

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
