### PR TITLE
Fix OAuth provider app doc link

### DIFF
--- a/docs/guides/Getting-Started/authentication/authentication-overview.md
+++ b/docs/guides/Getting-Started/authentication/authentication-overview.md
@@ -135,7 +135,7 @@ The tokens shown above are available via the VTEX IO context and are associated 
 VTEX allows stores to integrate with external identity providers to provide single sign on (SSO) experiences to shoppers and Administrative users. You can learn more about this in the article [Login (SSO)](https://developers.vtex.com/vtex-rest-api/docs/login-integration-guide) and below you can find more information on these and other SSO use cases:
 - [Store SSO with OAuth 2.0](https://developers.vtex.com/docs/guides/login-integration-guide-webstore-oauth2)
 - [Admin SSO with SAML 2.0](https://developers.vtex.com/docs/guides/login-integration-guide-admin-saml2)
-- [Use your VTEX account as an OAuth provider](https://github.com/vtex/oauth-provider)
+- [Use your VTEX account as an OAuth provider](https://developers.vtex.com/docs/apps/vtex.oauth-provider-admin@2.x)
 - [Unifying login for different accounts](https://developers.vtex.com/vtex-rest-api/docs/unifying-login-for-different-accounts)
 
 ## Shopper authentication for B2B stores


### PR DESCRIPTION
Fixing the OAuth provider app doc link in the authentication overview. 

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
