### PR TITLE
replacing bugged article with old version

### DIFF
--- a/docs/guides/Getting-Started/catalog-overview.md
+++ b/docs/guides/Getting-Started/catalog-overview.md
@@ -3,11 +3,10 @@ title: "Catalog"
 slug: "catalog-overview"
 hidden: false
 createdAt: "2021-03-26T15:35:50.014Z"
-updatedAt: "2022-09-27T21:01:32.508Z"
+updatedAt: "2023-04-24T21:01:32.508Z"
 ---
 
 > **Help us improve our documentation!** Tell us about your experience with this article by filling out [this form](https://forms.gle/fQoELRA1yfKDqmAb8).
-
 Catalog is your store's administration module for configuring the features related to your ecommerce products to make them available for customers on your website. This overview article goes over what you can accomplish with the VTEX Catalog, including relevant links to our developer documentation about this topic.
 
 ## Understanding Catalog architecture


### PR DESCRIPTION
Replacing current catalog overview article, with previous html from [this point in history](https://github.com/vtexdocs/dev-portal-content/blob/46d716d00292da27b15ed807c324825c3509a306/docs/guides/Getting-Started/catalog-overview.md), to correct bugged HTML render. 

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
