### PR TITLE
fixes of i18n on vtex-io-documentation-building-a-carousel-using-slider-layout.md

### DIFF
--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -14,7 +14,7 @@ A carousel is essentially a slider that showcases a collection of images. Hence,
 
 Check the instructions below for more information.
 
-## Instructions
+## Step by step
 
 1. Make sure your store is running `vtex.store@2.70.0` or higher.
 

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -10,7 +10,7 @@ Some block types in Store Framework carry and provide data to their child blocks
 
 These blocks are instances of a `list-context` interface called `lists`. They are exported by the `vtex.list-context` app.
 
-Since **a carousel is a slider with images displayed in it**, you can create one for your store using one of the available `list-context` instances together with a `slider-layout`, a generic layout block that allows you to create a Slider component from a set of other blocks.
+A carousel is essentially a slider that showcases a collection of images. Hence, to create a carousel for your store, you can use one of the available `list-context` instances together with a `slider-layout`, a versatile layout block that allows you to create a Slider component from a set of other blocks.
 
 In the instructions below, you can see how easy it is!
 

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -90,7 +90,7 @@ Check the instructions below for more information.
   }
 ```
 
-And there you go! Now you have a fully functioning carousel for your store.
+Now you have a fully functioning carousel for your store.
 
 ![gif-caroulsel-slider-layout](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-building-a-carousel-using-slider-layout-0.gif) *When inspecting the page, you will notice that the `carousel` block was not used to build the component.*
 

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -8,7 +8,7 @@ updatedAt: "2022-12-13T20:17:43.910Z"
 
 ## Introduction
 
-Some block types in VTEX IO Store Framework **carry and provide data to their child blocks** instead of rendering store components, such as `shelf`.
+Some block types in Store Framework carry and provide data to their child blocks instead of rendering storefront components.
 
 These blocks are instances of a `list-context` interface called `lists`. They are exported by the `vtex.list-context` app.
 

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -12,7 +12,7 @@ These blocks are instances of a `list-context` interface called `lists`. They ar
 
 A carousel is essentially a slider that showcases a collection of images. Hence, to create a carousel for your store, you can use one of the available `list-context` instances together with a `slider-layout`, a versatile layout block that allows you to create a Slider component from a set of other blocks.
 
-In the instructions below, you can see how easy it is!
+Check the instructions below for more information.
 
 ## Instructions
 

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -6,8 +6,6 @@ createdAt: "2020-06-03T16:02:44.233Z"
 updatedAt: "2022-12-13T20:17:43.910Z"
 ---
 
-## Introduction
-
 Some block types in Store Framework carry and provide data to their child blocks instead of rendering storefront components.
 
 These blocks are instances of a `list-context` interface called `lists`. They are exported by the `vtex.list-context` app.

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -92,7 +92,9 @@ Check the instructions below for more information.
 
 Now you have a fully functioning carousel for your store.
 
-![gif-caroulsel-slider-layout](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-building-a-carousel-using-slider-layout-0.gif) *When inspecting the page, you will notice that the `carousel` block was not used to build the component.*
+![gif-caroulsel-slider-layout](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-building-a-carousel-using-slider-layout-0.gif) 
+
+*When inspecting the page, you will notice that the `carousel` block was not used to build the component.*
 
 Note that you can also edit the information contained in `list-context.image-list` through Site Editor section in the Admin:
 

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -1,5 +1,5 @@
 ---
-title: "Building a Carousel using Slider Layout"
+title: "Building a carousel using Slider Layout"
 slug: "vtex-io-documentation-building-a-carousel-using-slider-layout"
 hidden: false
 createdAt: "2020-06-03T16:02:44.233Z"
@@ -8,19 +8,19 @@ updatedAt: "2022-12-13T20:17:43.910Z"
 
 ## Introduction
 
-There are block types in VTEX IO's Store Framework that instead of being responsible for rendering store components, such as the `shelf`, they **carry and provide data to their subsequent child blocks**.
+Some block types in VTEX IO Store Framework **carry and provide data to their child blocks** instead of rendering store components, such as `shelf`.
 
 These blocks are instances of a `list-context` interface called `lists`. They are exported by the `vtex.list-context` app.
 
-Since **a Carousel is a slider with images displayed on it**, you can create one for your store using one of the available `list-context` instances together with a `slider-layout`, a generic layout block that enables you to create a Slider component out of a set of other blocks.
+Since **a carousel is a slider with images displayed in it**, you can create one for your store using one of the available `list-context` instances together with a `slider-layout`, a generic layout block that allows you to create a Slider component from a set of other blocks.
 
-See the instructions below for how it can be easily done!
+In the instructions below, you can see how easy it is!
 
-## Step by step
+## Instructions
 
 1. Make sure your store is running `vtex.store@2.70.0` or higher.
 
-2. Add the following **dependencies** to your theme's `manifest.json` file:
+2. Add the following **dependencies** to the theme `manifest.json` file:
 
 ```json
 "vtex.store-image": "0.x",
@@ -29,14 +29,14 @@ See the instructions below for how it can be easily done!
 
 3. Declare the `list-context.image-list` block and use the `slider-layout` as its only child. Each desired image should be forwarded to the `list-context.image-list` as an object with the following properties:
 
-| Property      | Type                                                                                                                                | Description                                                   | Default value |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------- |
-| `image`       | `String`                                                                                                                            | Link for the image                                            | N/A           |
-| `mobileImage` | `String`                                                                                                                            | Link for the mobile image                                     | N/A           |
-| `description` | `String`                                                                                                                            | The image's description                                       | N/A           |
-| `link`        | [`Link`](https://github.com/vtex-apps/native-types/blob/f63aeeb8f6e62f4a9aaec052a8be34973be7389b/pages/contentSchemas.json#L52-L74) | Specifies the link the image will redirect to when clicked on | N/A           |
+| Property      | Type                                                                                                                                | Description                                                 | Default value |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------- |
+| `image`       | `string`                                                                                                                            | Link to the image.                                          | N/A           |
+| `mobileImage` | `string`                                                                                                                            | Link to the mobile image.                                   | N/A           |
+| `description` | `string`                                                                                                                            | The image description.                                      | N/A           |
+| `link`        | [`link`](https://github.com/vtex-apps/native-types/blob/f63aeeb8f6e62f4a9aaec052a8be34973be7389b/pages/contentSchemas.json#L52-L74) | Specifies the link the image will redirect to when clicked. | N/A           |
 
-*For example:*
+*Example:*
 
 ```json
 "list-context.image-list#demo": {
@@ -57,11 +57,11 @@ See the instructions below for how it can be easily done!
   },
 ```
 
-> ⚠️ Bear in mind that **list blocks do not render anything in your store**, they simply hold content that can be edited using the Site Editor and pass it down to their child blocks.
+> ⚠️ Note that **list blocks do not render anything in your store**, they simply hold content that can be edited using Site Editor and pass it down to their child blocks.
 
-4. Now that you've specified which data (in this case, which images) will be displayed in your slider using a `list` block, you need to configure the [slider properties](https://developers.vtex.com/docs/guides/vtex-slider-layout) themselves, meaning those of the `slider-layout`.
+4. Now that you have specified which information, an image in this case, will be displayed in your slider using a `list` block, you need to configure the [slider properties](https://developers.vtex.com/docs/guides/vtex-slider-layout) themselves, meaning the properties of `slider-layout`.
 
-*For example:*
+*Example:*
 
 ```json
   "list-context.image-list#demo": {
@@ -92,11 +92,10 @@ See the instructions below for how it can be easily done!
   }
 ```
 
-And there you go! You now have a fully functioning Carousel for your store.
+And there you go! Now you have a fully functioning carousel for your store.
 
-![gif-caroulsel-slider-layout](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-building-a-carousel-using-slider-layout-0.gif)
-*When inspecting the page you’ll notice that the `carousel` block was not used to build the component.*
+![gif-caroulsel-slider-layout](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-building-a-carousel-using-slider-layout-0.gif) *When inspecting the page, you will notice that the `carousel` block was not used to build the component.*
 
-Bear in mind that you are also able to edit data contained in `list-context.image-list` using the admin's Site Editor section:
+Note that you can also edit the information contained in `list-context.image-list` through Site Editor section in the Admin:
 
 ![carousel-slider-site-editor](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-building-a-carousel-using-slider-layout-1.png)

--- a/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
+++ b/docs/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-building-a-carousel-using-slider-layout.md
@@ -55,7 +55,7 @@ Check the instructions below for more information.
   },
 ```
 
-> ⚠️ Note that **list blocks do not render anything in your store**, they simply hold content that can be edited using Site Editor and pass it down to their child blocks.
+> ⚠️ Note that list blocks do not render anything in your store. Instead, they hold content that can be edited using Site Editor and pass it down to their child blocks.
 
 4. Now that you have specified which information, an image in this case, will be displayed in your slider using a `list` block, you need to configure the [slider properties](https://developers.vtex.com/docs/guides/vtex-slider-layout) themselves, meaning the properties of `slider-layout`.
 


### PR DESCRIPTION
It relates to task [LOC-10593](https://vtex-dev.atlassian.net/browse/LOC-10593) and KR 23Q2-KR1 ([Review all developer portal documentation in English](https://docs.google.com/document/d/1VduAYpjqdazhyGH5DvD9c52pMu1Xfj4RDx48QNjTFU0/edit)).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [X] Spelling and grammar accuracy (self-explanatory)


[LOC-10593]: https://vtex-dev.atlassian.net/browse/LOC-10593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ