### PR TITLE
Better organize the list of GTM/GA4 supported events

### DIFF
--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -79,7 +79,6 @@ Check out the available events that [Pixel Apps](https://developers.vtex.com/doc
 | vtex:productClick | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks) | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_item) |
 | vtex:addToCart | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add) | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_cart) |
 | vtex:removeFromCart | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove) | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#remove_from_cart) |
-| vtex:cartLoaded| [checkout](https://developers.google.com/analytics/devguides/collection/ua/gtm/enhanced-ecommerce#checkout) | [begin_checkout](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#begin_checkout) |
 | vtex:orderPlaced | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases) | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase) |
 
 

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -36,7 +36,7 @@ Once the GA4 Configuration tag is created, set up all GA4 events as follows:
 
 2. Import the container file by following Google’s [Import a container guide](https://support.google.com/tagmanager/answer/6106997?#import). This will add all the necessary tags, triggers, and variables to the workspace.
 
-![import-container](https://vtexhelp.vtexassets.com/assets/docs/src/gtm-import-container___755c64280e03b4df0105de7722099c65.png)
+![import-container](https://vtexhelp.vtexassets.com/assets/docs/src/new-ga4-tags-variables___b2619df57689429d97a8abd56a5f7d83.png)
 
 3. In the GTM container, go to the GA4 Configuration tag, and edit the **Measurement ID** field with your Google Tag ID ( G- ID).
 

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -80,7 +80,10 @@ Check out the available events that [Pixel Apps](https://developers.vtex.com/doc
 | vtex:addToCart | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add) | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_cart) |
 | vtex:removeFromCart | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove) | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#remove_from_cart) |
 | vtex:orderPlaced | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases) | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase) |
-
+| vtex:search | Not applicable | [search](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#search) |
+| vtex:share | Not applicable | [share](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#share) |
+| vtex:viewCart | Not applicable | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart) |
+| vtex:addToWishlist | Not applicable | [add_to_wishlist](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_wishlist) |
 
 ### GA4 events
 
@@ -94,9 +97,5 @@ The GTM app listens to the following events and sends them in the following corr
 | vtex:addShippingInfo | add_shipping_info |
 | vtex:login | login |
 | vtex:signUp | sign_up |
-| vtex:viewCart | view_cart |
 | vtex:beginCheckout | begin_checkout |
 | vtex:refund | refund |
-| vtex:addToWishlist | add_to_wishlist |
-| vtex:search | search |
-| vtex:share| share |

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -85,6 +85,16 @@ Check out the available events that [Pixel Apps](https://developers.vtex.com/doc
 | vtex:viewCart | Not applicable | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart) |
 | vtex:addToWishlist | Not applicable | [add_to_wishlist](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_wishlist) |
 
+### Partially-supported events
+
+The following events are not fully supported yet. Although the GTM app may listen and format them into GA4, their VTEX event triggers have not been implemented yet:
+
+| VTEX               | GA4                                                                                                                                  |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| vtex:login         | [login](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#login)                     |
+| vtex:signUp        | [sign_up](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#sign_up)                 |
+| vtex:refund        | [refund](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#refund)                   |
+
 ### GA4 events
 
 Besides the events listed in the previous sections, GA4 has new events that stores can start tracking. The full list can be found on [Google documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm).
@@ -95,7 +105,4 @@ The GTM app listens to the following events and sends them in the following corr
 | ------------- | ----- |
 | vtex:addPaymentInfo | add_payment_info |
 | vtex:addShippingInfo | add_shipping_info |
-| vtex:login | login |
-| vtex:signUp | sign_up |
 | vtex:beginCheckout | begin_checkout |
-| vtex:refund | refund |

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -70,39 +70,46 @@ This event is commonly attached to the promotion banners carousel displayed by t
 
 Check out the available events that [Pixel Apps](https://developers.vtex.com/docs/guides/pixel-apps) can listen to and their equivalent names in UA and GA4:
 
-| VTEX                   | UA                                                                                              | GA4                                                                                                                                    |
-|------------------------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| vtex:promoView         | [promoView](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions)     | [view_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_promotion)     |
-| vtex:promotionClick    | [promoClick](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks)         | [select_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_promotion) |
-| vtex:productView       | [detail](https://developers.google.com/tag-manager/enhanced-ecommerce#details)                  | [view_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item)               |
-| vtex:productImpression | [impressions](https://developers.google.com/tag-manager/enhanced-ecommerce#product-impressions) | [view_item_list](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item_list)     |
-| vtex:productClick      | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks)            | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_item)           |
-| vtex:addToCart         | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add)                         | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_cart)           |
-| vtex:removeFromCart    | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove)                   | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart) |
-| vtex:orderPlaced       | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases)              | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#purchase)                 |
-| vtex:search            | Not applicable                                                                                  | [search](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#search)                     |
-| vtex:share             | Not applicable                                                                                  | [share](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#share)                       |
-| vtex:viewCart          | Not applicable                                                                                  | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart)               |
-| vtex:addToWishlist     | Not applicable                                                                                  | [add_to_wishlist](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_wishlist)   |
+| VTEX                   | UA                                                                                              | GA4                                                                                                                                      |
+|------------------------|-------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| vtex:promoView         | [promoView](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions)     | [view_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_promotion)       |
+| vtex:promotionClick    | [promoClick](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks)         | [select_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_promotion)   |
+| vtex:productImpression | [impressions](https://developers.google.com/tag-manager/enhanced-ecommerce#product-impressions) | [view_item_list](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item_list)       |
+| vtex:productClick      | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks)            | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_item)             |
+| vtex:productView       | [detail](https://developers.google.com/tag-manager/enhanced-ecommerce#details)                  | [view_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item)                 |
+| vtex:addToCart         | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add)                         | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_cart)             |
+| vtex:removeFromCart    | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove)                   | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart)   |
+| vtex:viewCart          | Not applicable                                                                                  | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart)                 |
+| vtex:beginCheckout     | checkout                                                                                        | [begin_checkout](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#refund)               |
+| vtex:addShippingInfo   | Not applicable                                                                                  | [add_shipping_info](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_shipping_info) |
+| vtex:addPaymentInfo    | Not applicable                                                                                  | [add_payment_info](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_payment_info)   |
+| vtex:orderPlaced       | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases)              | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#purchase)                   |
+| vtex:refund            | Not applicable                                                                                  | [refund](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#refund)                       |
+| vtex:search            | Not applicable                                                                                  | [search](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#search)                       |
+| vtex:share             | Not applicable                                                                                  | [share](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#share)                         |
+| vtex:addToWishlist     | Not applicable                                                                                  | [add_to_wishlist](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_wishlist)     |
 
 ### Partially-supported events
 
-The following events are not fully supported yet. Although the GTM app may listen and format them into GA4, their VTEX event triggers have not been implemented yet:
+The following events are not fully supported yet. Although the GTM app will listen and format them into GA4, their VTEX event triggers have not been implemented yet:
 
-| VTEX               | GA4                                                                                                                                  |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| vtex:login         | [login](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#login)                     |
-| vtex:signUp        | [sign_up](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#sign_up)                 |
-| vtex:refund        | [refund](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#refund)                   |
+| VTEX        | GA4                                                                                                                  |
+|-------------|----------------------------------------------------------------------------------------------------------------------|
+| vtex:login  | [login](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#login)     |
+| vtex:signUp | [sign_up](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#sign_up) |
 
-### Checkout events
+## Container Template Changelog
 
-The following events are supported by VTEX's Checkout module. This module does not loads the GTM app, but it still pushes the events to the data layer.
+This section contains the changes history of the container template file. The most current version can be downloaded in the [Setting up GA4 events](#step-1-setting-up-ga4-events) section.
 
-| GA4                                                                                                                                      |
-|------------------------------------------------------------------------------------------------------------------------------------------|
-| [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart)                 |
-| [begin_checkout](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#begin_checkout)       |
-| [add_payment_info](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_payment_info)   |
-| [add_shipping_info](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_shipping_info) |
-| [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart)   |
+### [1.1.0] - 2023-05-11
+
+### Refactored
+
+- Organized the tags, triggers, and variables in a single "GA4" folder and followed a naming standard.
+
+### [1.0.0] - 2023-05-03
+
+#### Added
+
+- The first version of the container template.

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -95,14 +95,14 @@ The following events are not fully supported yet. Although the GTM app may liste
 | vtex:signUp        | [sign_up](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#sign_up)                 |
 | vtex:refund        | [refund](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#refund)                   |
 
-### GA4 events
+### Checkout events
 
-Besides the events listed in the previous sections, GA4 has new events that stores can start tracking. The full list can be found on [Google documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm).
+The following events are supported by VTEX's Checkout module. This module does not loads the GTM app, but it still pushes the events to the data layer.
 
-The GTM app listens to the following events and sends them in the following corresponding GA4 format:
-
-| VTEX          | GA4   |
-| ------------- | ----- |
-| vtex:addPaymentInfo | add_payment_info |
-| vtex:addShippingInfo | add_shipping_info |
-| vtex:beginCheckout | begin_checkout |
+| GA4                                                                                                                                      |
+|------------------------------------------------------------------------------------------------------------------------------------------|
+| [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart)                 |
+| [begin_checkout](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#begin_checkout)       |
+| [add_payment_info](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_payment_info)   |
+| [add_shipping_info](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_shipping_info) |
+| [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart)   |

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -104,7 +104,7 @@ This section contains the changes history of the container template file. The la
 
 ### 2023-05-11
 
-### Refactored
+#### Refactored
 
 - Organized the tags, triggers, and variables in a single "GA4" folder and followed a naming standard.
 

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -98,17 +98,17 @@ The following events are not fully supported yet. Although the GTM app will list
 | vtex:login  | [login](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#login)     |
 | vtex:signUp | [sign_up](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#sign_up) |
 
-## Container Template Changelog
+## Container template file changelog
 
-This section contains the changes history of the container template file. The most current version can be downloaded in the [Setting up GA4 events](#step-1-setting-up-ga4-events) section.
+This section contains the changes history of the container template file. The latest version can be downloaded in [Step 1 - Setting up GA4 events](#step-1-setting-up-ga4-events).
 
-### [1.1.0] - 2023-05-11
+### 2023-05-11
 
 ### Refactored
 
 - Organized the tags, triggers, and variables in a single "GA4" folder and followed a naming standard.
 
-### [1.0.0] - 2023-05-03
+### 2023-05-03
 
 #### Added
 

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -72,14 +72,14 @@ Check out the available events that [Pixel Apps](https://developers.vtex.com/doc
 
 | VTEX          | UA    | GA4   |
 | ------------- | ----- | ----- |
-| vtex:promoView | [promoView](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions) | [view_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_promotion) |
-| vtex:promotionClick | [promoClick](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks) | [select_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_promotion) |
-| vtex:productView | [detail](https://developers.google.com/tag-manager/enhanced-ecommerce#details) | [view_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_item) |
-| vtex:productImpression | [impressions](https://developers.google.com/tag-manager/enhanced-ecommerce#product-impressions) | [view_item_list](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_item_list) |
-| vtex:productClick | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks) | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_item) |
-| vtex:addToCart | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add) | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_cart) |
-| vtex:removeFromCart | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove) | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#remove_from_cart) |
-| vtex:orderPlaced | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases) | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase) |
+| vtex:promoView | [promoView](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions) | [view_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_promotion) |
+| vtex:promotionClick | [promoClick](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks) | [select_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_promotion) |
+| vtex:productView | [detail](https://developers.google.com/tag-manager/enhanced-ecommerce#details) | [view_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item) |
+| vtex:productImpression | [impressions](https://developers.google.com/tag-manager/enhanced-ecommerce#product-impressions) | [view_item_list](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item_list) |
+| vtex:productClick | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks) | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_item) |
+| vtex:addToCart | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add) | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_cart) |
+| vtex:removeFromCart | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove) | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart) |
+| vtex:orderPlaced | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases) | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#purchase) |
 | vtex:search | Not applicable | [search](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#search) |
 | vtex:share | Not applicable | [share](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#share) |
 | vtex:viewCart | Not applicable | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart) |

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-setting-up-google-tag-manager.md
@@ -70,20 +70,20 @@ This event is commonly attached to the promotion banners carousel displayed by t
 
 Check out the available events that [Pixel Apps](https://developers.vtex.com/docs/guides/pixel-apps) can listen to and their equivalent names in UA and GA4:
 
-| VTEX          | UA    | GA4   |
-| ------------- | ----- | ----- |
-| vtex:promoView | [promoView](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions) | [view_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_promotion) |
-| vtex:promotionClick | [promoClick](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks) | [select_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_promotion) |
-| vtex:productView | [detail](https://developers.google.com/tag-manager/enhanced-ecommerce#details) | [view_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item) |
-| vtex:productImpression | [impressions](https://developers.google.com/tag-manager/enhanced-ecommerce#product-impressions) | [view_item_list](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item_list) |
-| vtex:productClick | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks) | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_item) |
-| vtex:addToCart | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add) | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_cart) |
-| vtex:removeFromCart | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove) | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart) |
-| vtex:orderPlaced | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases) | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#purchase) |
-| vtex:search | Not applicable | [search](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#search) |
-| vtex:share | Not applicable | [share](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#share) |
-| vtex:viewCart | Not applicable | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart) |
-| vtex:addToWishlist | Not applicable | [add_to_wishlist](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_wishlist) |
+| VTEX                   | UA                                                                                              | GA4                                                                                                                                    |
+|------------------------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| vtex:promoView         | [promoView](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions)     | [view_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_promotion)     |
+| vtex:promotionClick    | [promoClick](https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks)         | [select_promotion](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_promotion) |
+| vtex:productView       | [detail](https://developers.google.com/tag-manager/enhanced-ecommerce#details)                  | [view_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item)               |
+| vtex:productImpression | [impressions](https://developers.google.com/tag-manager/enhanced-ecommerce#product-impressions) | [view_item_list](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_item_list)     |
+| vtex:productClick      | [click](https://developers.google.com/tag-manager/enhanced-ecommerce#product-clicks)            | [select_item](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_item)           |
+| vtex:addToCart         | [add](https://developers.google.com/tag-manager/enhanced-ecommerce#add)                         | [add_to_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_cart)           |
+| vtex:removeFromCart    | [remove](https://developers.google.com/tag-manager/enhanced-ecommerce#remove)                   | [remove_from_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#remove_from_cart) |
+| vtex:orderPlaced       | [purchase](https://developers.google.com/tag-manager/enhanced-ecommerce#purchases)              | [purchase](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#purchase)                 |
+| vtex:search            | Not applicable                                                                                  | [search](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#search)                     |
+| vtex:share             | Not applicable                                                                                  | [share](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#share)                       |
+| vtex:viewCart          | Not applicable                                                                                  | [view_cart](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#view_cart)               |
+| vtex:addToWishlist     | Not applicable                                                                                  | [add_to_wishlist](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#add_to_wishlist)   |
 
 ### Partially-supported events
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

https://developers.vtex.com/docs/guides/vtex-io-documentation-setting-up-google-tag-manager

Better organize the table of supported events to clarify which events are fully supported and which are not.

We decided to also add a new section to describe the changes we make to the GTM Container Template.

#### Screenshots or example usage

Before|After
-|-
![CleanShot 2023-05-11 at 14 08 39@2x](https://github.com/vtexdocs/dev-portal-content/assets/381395/ad27b99e-87fd-4870-b385-3e4d7e22f218)|![CleanShot 2023-05-11 at 14 09 47@2x](https://github.com/vtexdocs/dev-portal-content/assets/381395/ba5f1436-f8ef-4efe-b4df-0b4c5aa58eb3)

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
