### PR TITLE
Fix: Deleted `step 2` in the GTM installation process

### DIFF
--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-installing-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-installing-google-tag-manager.md
@@ -10,8 +10,8 @@ category: "Storefront Development"
 
 This guide provides a step-by-step on how to install and configure Google Tag Manager (GTM) on Store Framework stores. The guide also highlights some restrictions to avoid performance issues and unpredictable behavior, including blocklists for custom HTML tags and variables.
 
-> ⚠️ If you have already installed the Google Tag Manager app, navigate to this guide's section titled [Create a Google Analytics 4 property](#create-a-google-analytics-4-property) to create the property. Then, follow the instructions in [Step 2: to enable the GA4 setting in the GTM app](#step-2-enabling-the-ga4-setting-in-the-gtm-app).
->
+> ⚠️ If you have already installed the Google Tag Manager app, navigate to this guide's section titled [Create a Google Analytics 4 property](#create-a-google-analytics-4-property) to create the property and follow along. 
+
 ## Before you start
 
 Before proceeding with the installation, ensure you match the following requisites:

--- a/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-installing-google-tag-manager.md
+++ b/docs/vtex-io/Storefront-Guides/google-tag-manager/vtex-io-documentation-installing-google-tag-manager.md
@@ -10,7 +10,7 @@ category: "Storefront Development"
 
 This guide provides a step-by-step on how to install and configure Google Tag Manager (GTM) on Store Framework stores. The guide also highlights some restrictions to avoid performance issues and unpredictable behavior, including blocklists for custom HTML tags and variables.
 
-> ⚠️ If you have already installed the Google Tag Manager app, navigate to this guide's section titled [Create a Google Analytics 4 property](#create-a-google-analytics-4-property) to create the property and follow along. 
+> ⚠️ If you have already installed the Google Tag Manager app, navigate to this guide's section titled [Create a Google Analytics 4 property](#create-a-google-analytics-4-property) to create the property and follow along.
 
 ## Before you start
 


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Deleted the mention of `Step 2` since it no longer exists in the doc. 