### PR TITLE
Fixes of i18n on a vtex-io-documentation file

### DIFF
--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-4-configuringyourappsettings.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-4-configuringyourappsettings.md
@@ -26,7 +26,7 @@ In the following steps, you will learn how to make your Pixel app read the user 
 - `title` - Pixel app name.
 - `type` - JSON Schema type (this must always be completed as `object`).
 - `description` *(Optional)*  - Description of the `settingsSchema` field.
-- `properties` - Keys that define the user identification. Possible keys for `properties` are: `title` (user identification title), `description` (user identification description), and `type` (property type to define how users should input their identification). Note that these keys will be displayed to the app users.
+- `properties` - Key-value pairs that define the user identification. Possible keys for `properties` are: `title` (user identification title), `description` (user identification description), and `type` (property type to define how users should input their identification). Note that these keys will be displayed to the app users.
 
 ```json
 "settingsSchema": {

--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-4-configuringyourappsettings.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-4-configuringyourappsettings.md
@@ -4,28 +4,29 @@ slug: "vtex-io-documentation-4-configuringyourappsettings"
 hidden: false
 category: "App Development"
 seeAlso:
- - "/docs/guides/vtex-io-documentation-5-writingtheheaderandbodyscripts"
+  - "/docs/guides/vtex-io-documentation-5-writingtheheaderandbodyscripts"
 createdAt: "2020-11-03T18:19:23.222Z"
 updatedAt: "2022-12-13T20:17:44.408Z"
 ---
-When developing a Pixel app, you must define a way to identify whether or not a VTEX account has the necessary permissions to communicate with the third-party solution in question. Otherwise, sharing data between the store and the solution won't be possible.
 
-This verification is generally performed via a user identification issued by the third-party solution. The user identification is an individual and untransferable value that identifies if you have the required permissions to use that solution. Think of the Google Tag Manager Pixel app: in order to use it, you must provide a user identification previously issued.
+When developing a Pixel app, you must define a way to identify if a VTEX account has the necessary permissions to communicate with the third-party solution in question. Otherwise, sharing data between the store and the solution will not be possible.
 
-In the following step by step, you'll learn how to make your Pixel app read the user identification and determine whether or not a user is allowed.
+This verification is generally performed via a user identification issued by the third-party solution. The user identification is an individual and nontransferable value that identifies if you have the required permissions to use that solution. Think of the Google Tag Manager Pixel app — you must provide a previously issued user identification, in order to use it.
 
-## Step by step
+In the following steps, you will learn how to make your Pixel app read the user identification and determine if a user is allowed.
+
+## Instructions
 
 1. Open the `manifest.json` file.
-2. Change the  `vendor` field value (`vtex`) to the name of the VTEX account in which you are working.
-3. Change the `name` and `title` field values with the name you wish to give your app. Please refer to our [app-naming guidelines](https://developers.vtex.com/docs/guides/vtex-io-documentation-filling-the-application-form-for-development/#guidelines).
+2. Change the `vendor` field value (`vtex`) to the name of the VTEX account in which you are working.
+3. Change the `name` and `title` field values with the name you want to give your app. Please see our [app naming guidelines](https://developers.vtex.com/docs/guides/vtex-io-documentation-filling-the-application-form-for-development/#guidelines).
 4. Declare the `settingsSchema` field. This field will be used to receive the user identification information.
 5. Inside the `settingsSchema` object, declare a JSON Schema containing the following fields:
 
 - `title` - Pixel app name.
-- `type` - JSON Schema type (this must always be filled in as `object`).
+- `type` - JSON Schema type (this must always be completed as `object`).
 - `description` *(Optional)*  - Description of the `settingsSchema` field.
-- `properties` - Set of keys that defines the user identification. Possible keys for `properties` are: `title` (user identification title), `description` (user identification description), and `type` (property type to define how users should input their identifications). Notice that these keys will be displayed to the app's users.
+- `properties` - Keys that define the user identification. Possible keys for `properties` are: `title` (user identification title), `description` (user identification description), and `type` (property type to define how users should input their identification). Note that these keys will be displayed to the app users.
 
 ```json
 "settingsSchema": {
@@ -34,14 +35,14 @@ In the following step by step, you'll learn how to make your Pixel app read the 
   "properties": {
     "gtmId": {
       "title": "SAMPLE FIELD",
-      "description": "Enter the ID (GTM-XXXX) from your Google Tag Manager",
+      "description": "Enter your Google Tag Manager ID (GTM-XXXX)",
       "type": "string"
     }
   }
 },
 ```
 
-If needed, you can also use the `properties` object to read the user preferences. Check the following example:
+If necessary, you can also use the `properties` object to read the user preferences. Check the following example:
 
 ```json
 "settingsSchema": {
@@ -50,16 +51,16 @@ If needed, you can also use the `properties` object to read the user preferences
   "properties": {
     "gtmId": {
       "title": "SAMPLE FIELD",
-      "description": "Enter the ID (GTM-XXXX) from your Google Tag Manager",
+      "description": "Enter your Google Tag Manager ID (GTM-XXXX)",
       "type": "string"
     },
     "allowCustomHtmlTags": {
-        "title": "Allow Custom HTML tags",
-        "description": "Beware that using Custom HTML tags can drastically impact the store's performance",
+        "title": "Allow custom HTML tags",
+        "description": "Keep in mind that using custom HTML tags can drastically impact store performance",
         "type": "boolean"
     }
   }
 },
 ```
 
-> ℹ️ Please refer to the [JSON Schema documentation](http://json-schema.org/understanding-json-schema/) while building your app's `settingSchema` field.
+> ℹ️ Please read the [JSON Schema documentation](http://json-schema.org/understanding-json-schema/) while building the `settingSchema` field of your app.

--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-4-configuringyourappsettings.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-4-configuringyourappsettings.md
@@ -15,7 +15,7 @@ This verification is generally performed via a user identification issued by the
 
 In the following steps, you will learn how to make your Pixel app read the user identification and determine if a user is allowed.
 
-## Instructions
+## Step by step
 
 1. Open the `manifest.json` file.
 2. Change the `vendor` field value (`vtex`) to the name of the VTEX account in which you are working.


### PR DESCRIPTION
It relates to task [LOC-10748](https://vtex-dev.atlassian.net/browse/LOC-10748) and KR 23Q2-KR1 ([Review all developer portal documentation in English](https://docs.google.com/document/d/1VduAYpjqdazhyGH5DvD9c52pMu1Xfj4RDx48QNjTFU0/edit)).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [X] Spelling and grammar accuracy (self-explanatory)


[LOC-10748]: https://vtex-dev.atlassian.net/browse/LOC-10748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ