### PR TITLE
Fixes of i18n on vtex-io-documentation-6-listeningtostoreevents.md

### DIFF
--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-6-listeningtostoreevents.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-6-listeningtostoreevents.md
@@ -23,7 +23,7 @@ In these scenarios, your Pixel app must be able to listen to the desired events 
 - `pageView` - Triggered on every loaded page view.
 - `productImpression` - Triggered when product information is visible on the page currently being accessed by users.
 
-> ℹ️ All the available event properties are written in **TypeScript**. You can see the properties [here](https://github.com/vtex-apps/pixel-app-template/blob/master/react/typings/events.d.ts).
+> ℹ️ All the available event properties are written in TypeScript. For a comprehensive list of properties, please refer to [this file](https://github.com/vtex-apps/pixel-app-template/blob/master/react/typings/events.d.ts).
 
 This is an example of an event implementation in the [Google Tag Manager Pixel app](https://github.com/vtex-apps/google-tag-manager/blob/master/react/index.tsx):
 


### PR DESCRIPTION
It relates to task [LOC-10863](https://vtex-dev.atlassian.net/browse/LOC-10863) and KR 23Q2-KR1 ([Review all developer portal documentation in English](https://docs.google.com/document/d/1VduAYpjqdazhyGH5DvD9c52pMu1Xfj4RDx48QNjTFU0/edit)).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [X] Spelling and grammar accuracy (self-explanatory)


[LOC-10863]: https://vtex-dev.atlassian.net/browse/LOC-10863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ