### PR TITLE
Master data v2 schema limit

### DIFF
--- a/docs/guides/Master-Data/getting-started-1/starting-to-work-on-master-data-with-json-schema.md
+++ b/docs/guides/Master-Data/getting-started-1/starting-to-work-on-master-data-with-json-schema.md
@@ -65,6 +65,8 @@ You can add these examples to [JSON Schema Validator](http://www.jsonschemavalid
 
 The JSON Schema validates only the fields configured in properties. The exceeding fields will be maintained without validation. To preserve only the fields configured in the JSON schema, see the `additionalProperties` property information in [external documentation about JSON schema](https://json-schema.org/understanding-json-schema/reference/object.html#properties).
 
+> ⚠️ Master Data v2 data entities can have up to 60 schemas per entity.
+
 ## Indexing fields
 
 Use the property `v-indexed` to set up indexed fields. You must add the field to the properties to generate the indexer configuration with the right type.

--- a/docs/vtex-io/App-Guides/create-master-data-crud-app.md
+++ b/docs/vtex-io/App-Guides/create-master-data-crud-app.md
@@ -152,11 +152,11 @@ At this point, your app may not recognize the folder created by `vtex setup`, le
 
 ### Data entities and schemas
 
-You can set more than one data entity in you app. To do so, create one folder inside the `masterdata` folder for each data entity you wish to create. Each must have its own `schema.json` with a valid [JSON schema](https://developers.vtex.com/vtex-rest-api/docs/starting-to-work-on-master-data-with-json-schema).
+You can set more than one data entity in your app. To do so, create one folder inside the `masterdata` folder for each data entity you wish to create. Each must have its own `schema.json` with a valid [JSON schema](https://developers.vtex.com/vtex-rest-api/docs/starting-to-work-on-master-data-with-json-schema).
 
 Your app creates regular Master Data entities, which can be accessed via the [Master Data v2 endpoints](https://developers.vtex.com/docs/api-reference/master-data-api-v2#overview). The name of the entity created follows this pattern: `{vendor}_{appName}_{entityName}`.
 
-> ⚠️ Whenever you install or link a different version of your app, the Master Data builder cerates a new schema with the app’s name and version.
+> ⚠️ Whenever you install or link a different version of your app, the Master Data builder cerates a new schema with the app’s name and version. Note that Master Data v2 data entities have a limit of 60 schemas per entity. So you must [delete unused schemas](https://developers.vtex.com/docs/api-reference/master-data-api-v2#delete-/api/dataentities/-dataEntityName-/schemas/-schemaName-) to prevent from running into issues.
 
 ## Usage
 


### PR DESCRIPTION
Adding warnings about the limit of 60 schemas per data entity to two guides.

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
