### PR TITLE
Fixes of i18n on vtex-io-documentation-4-declaring-a-theme-block.md

### DIFF
--- a/docs/vtex-io/Getting-Started/getting-started-3/vtex-io-documentation-3-settingyourstoretheme.md
+++ b/docs/vtex-io/Getting-Started/getting-started-3/vtex-io-documentation-3-settingyourstoretheme.md
@@ -21,9 +21,7 @@ To jumpstart our storefront project, we'll utilize a pre-defined [Store Theme bo
 
 Before downloading the Store Theme app, make sure your VTEX account has the [Store Edition](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app) app installed, as recommended in this track's second step. Otherwise, you won't be able to successfully implement the VTEX Store Framework.
 
-## Step by step
-
-### Step 1 - Downloading the Store Theme app
+## Step 1 - Downloading the Store Theme app
 
 The VTEX IO CLI simplifies the process of starting a new VTEX IO project by proving a list of pre-defined app templates. In the following steps, we will kick-start a new Store Theme project.
 
@@ -48,7 +46,7 @@ The VTEX IO CLI simplifies the process of starting a new VTEX IO project by prov
 4. Open the `minimum-boilerplate-theme` in the code editor of your preference.
 5. Go to the `manifest.json` file and replace the predefined `vendor`  value with the account name of the store you're developing. This will ensure that you can publish the theme app correctly later on.
 
-### Step 2 - Understanding the Store Theme's structure
+## Step 2 - Understanding the Store Theme's structure
 
 In this section, we'll take a closer look at the files and folders that make up the Store Theme app's structure. Understanding the purpose of each file and folder will help you configure the store's templates and visual theme according to your needs.
 
@@ -62,7 +60,7 @@ The following files and folders comprise the Store Theme app:
 
 It is important to note that the Store Theme boilerplate app you copied to your local machine already defines a basic theme for your store. You'll notice that code has already been declared in the `store` and `styles` folders, providing default components and styles to help you build your desired store frontend.
 
-### Step 3 - Linking your local code to the VTEX IO platform
+## Step 3 - Linking your local code to the VTEX IO platform
 
 After setting up your local development environment and cloning the Store Theme boilerplate app, you'll want to sync your changes with the VTEX IO platform to preview them on your website. Since the boilerplate app already includes a default theme, you can immediately see how this theme affect your website's frontend. This is done using a [development workspace](https://developers.vtex.com/docs/guides/vtex-io-documentation-creating-a-development-workspace) and the `vtex link` command, which sends your code to the platform and allows you to see your changes in real-time.
 
@@ -83,7 +81,7 @@ After setting up your local development environment and cloning the Store Theme 
 
 By successfully running this command in your terminal, your local code is sent to the VTEX IO cloud-native infrastructure and it is reflected in the development workspace you are currently working in. Now, any changes you make to your Store Theme app files will be automatically reflected on your website in real-time.
 
-### Step 4 - Checking out your new store theme
+## Step 4 - Checking out your new store theme
 
 After linking your local code to the VTEX IO platform, you can check out your new store theme in action on your store's website. To do this, navigate to `https://{workspaceName}--{account}.myvtex.com`, replacing the values between brackets with your development workspace and VTEX account name.
 

--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developing-storefront-apps-using-react-and-vtex-io/vtex-io-documentation-4-declaring-a-theme-block.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developing-storefront-apps-using-react-and-vtex-io/vtex-io-documentation-4-declaring-a-theme-block.md
@@ -14,7 +14,7 @@ With the app template already copied, we will now create a new theme block. Foll
 
 ## Before you start
 
-- Make sure you are familiar with the core concepts of Store Framework, including blocks, store themes, and templates. If you need to refresh your knowledge or get acquainted with these concepts, you can refer to the getting started tutorial on [**building storefronts with Store Framework**](https://developers.vtex.com/docs/guides/getting-started-3).
+- Make sure you are familiar with the core concepts of Store Framework, including blocks, store themes, and templates. If you need to refresh your knowledge or get acquainted with these concepts, you can refer to the getting started tutorial on [building storefronts with Store Framework](https://developers.vtex.com/docs/guides/getting-started-3).
 
 - Check our recommended practices for tooling, features, flexibility, scalability, performance, accessibility, internationalization, and styling. For more information, please refer to [Best practices for developing custom storefront components](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components).
 

--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developing-storefront-apps-using-react-and-vtex-io/vtex-io-documentation-4-declaring-a-theme-block.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developing-storefront-apps-using-react-and-vtex-io/vtex-io-documentation-4-declaring-a-theme-block.md
@@ -5,56 +5,57 @@ hidden: false
 createdAt: "2021-03-25T20:58:43.073Z"
 updatedAt: "2022-12-13T20:17:44.349Z"
 category: "App Development"
+excerpt: "Learn how to create a new theme block."
 seeAlso:
   - "/docs/guides/vtex-io-documentation-5-defining-styles"
 ---
 
-With a copy of the app template, we will now create a **new theme block**. Follow the instructions below to create the new theme block.
+With the app template already copied, we will now create a new theme block. Follow the instructions below to create the new theme block.
 
-## Before you begin
+## Before you start
 
-1. You must be familiar with VTEX Store Framework and fully understand what a block, store theme, and template are. If you are not familiar with these concepts or want to refresh them before working on the settings, read [**Building stores with Store Framework**](https://developers.vtex.com/docs/guides/getting-started-3).
+- Make sure you are familiar with the core concepts of Store Framework, including blocks, store themes, and templates. If you need to refresh your knowledge or get acquainted with these concepts, you can refer to the getting started tutorial on [**building storefronts with Store Framework**](https://developers.vtex.com/docs/guides/getting-started-3).
 
-2. When creating a storefront component, follow the best practices for tooling, features, flexibility, scalability, performance, accessibility, internationalization, and styling when creating your storefront component. Read [**Developing custom storefront components**](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components) to learn more.
+- Check our recommended practices for tooling, features, flexibility, scalability, performance, accessibility, internationalization, and styling. For more information, please refer to [Best practices for developing custom storefront components](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components).
 
 ## Understanding interfaces
 
-An interface works as an API (*application programming interface*) that defines the theme blocks’ behavior following the React component they render.
+An interface describes the shape of an object, including its properties and data types. This is crucial for ensuring type safety and preventing potential bugs.
 
-In the same way that an API uses parameters to define how the conversation with a server will take place, the interface uses what we call *keys*.
+In VTEX Store Framework, interfaces are used to link theme blocks to their corresponding React components. This way, interfaces provide a set of rules that dictate the behavior of theme blocks when rendering their React components and the available properties and methods.
 
-**The interfaces, using their keys, define a block's behavior when implementing and rendering in a store theme**.
-
-This means that, for each theme block exported by your app, you will need to define an [interface](https://developers.vtex.com/docs/guides/vtex-io-documentation-interface), which will link the block to the React component of your choice.
+For each theme block exported by your app, you should define a corresponding [interface](https://developers.vtex.com/docs/guides/vtex-io-documentation-interface) that defines the props available to the React component. 
 
 The following table shows some possible keys that could be added to the block interface, as well as their respective descriptions:
 
 | Key           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `component`   | Name of the React component linked to the theme block. In other words, the name of the React component that the theme block will render.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `allowed`     | List of other theme blocks that, when declared, will help build the desired React component. In practice, blocks declared as `allowed` must be declared in the theme app (Store Theme) as children of the block you developed.                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `composition` | Defines whether the children of the block you are developing will have a specific rendering position in the interface. Remember that when defining the `composition` key, you don't control the position of the block it defines but the position of the children of that block. Possible values for this key are `blocks` (the child blocks have a specific position in the interface based on the React component on which they are based) or `children` (the position of the child blocks depends exclusively on how they are declared in the theme). If no value is defined for the `composition` key, the platform default is `blocks.` |
-| `device`      | Defines whether your theme block is designed for mobile or desktop devices. Possible values are `mobile` (designed for mobile devices) and `desktop` (designed for desktop devices).                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `component`   | Name of the React component that the theme block will render.|
+| `allowed` | List of other theme blocks that help build the desired React component. When declared, these blocks can be included as children to the block you developed in the Store Theme app.|
+| `composition` | Defines the rendering position of the children of the block that you are developing. Remember that when defining the `composition` key, you don't control the position of the block it defines but the position of the children of that block. Possible values for this key are `blocks` (the child blocks have a specific position in the interface based on the React component on which they are based) or `children` (the position of the child blocks depends exclusively on how they are declared in the theme). If no value is defined for the `composition` key, the platform default is `blocks.` |
+| `device`      | Defines whether your theme block is designed for mobile or desktop devices. Possible values are `mobile` and `desktop`.                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `required`    | List of theme blocks that must be rendered in the interface to support the block rendering you are developing.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `around`      | List of theme blocks that must be rendered in the interface around your new block for it to work correctly.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `before`      | List of theme blocks that must be rendered in the interface before your block (above it) for it to work correctly. For example: header.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `after`       | List of theme blocks that must be rendered in the interface after your block (below it) for it to work correctly. For example: footer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `preview`     | Defines the behavior of the page while the block is loading.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `render`      | Defines the block rendering type. Possible values are `lazy` (the block is only rendered when a user interacts with it), `server` (the block is rendered from the server side), or `client` (the block is rendered from the client side, by the browser).                                                                                                                                                                                                                                                                                                                                                                                    |
+| `render`      | Defines the block rendering type. Possible values are `lazy` (the block is only rendered when a user interacts with it), `server` (the block is rendered from the server side), or `client` (the block is rendered from the client side.                                                                                                                                                                                                                                                                                                                                                                                    |
 
 The only mandatory key that needs to be declared in a block interface is `component`. You have to declare the other ones based on the desired scenario for your new theme block.
 
-## Declaring an interface
+## Step 1 - Declaring an interface
 
-We declare the interface of one or more blocks in the app `interfaces.json` file, used by [Store Builder](https://developers.vtex.com/docs/guides/vtex-io-documentation-builders/) to correctly build your website's *frontend*.
+To add new custom blocks to your storefront, you need to declare their interfaces in the `interfaces.json` file of your store theme app. 
 
-For this example, we will create an interface for a basic block called `hello-world` (based on the React `HelloWorld` component).
+> The `interfaces.json` file is used by the `store` [Builder](https://developers.vtex.com/docs/guides/vtex-io-documentation-builders/) during the website building process.
+
+For this example, we will create an interface for a basic block called `hello-world`. This block will render the React component defined in `HelloWorld.tsx`.
 
 When following these steps, remember to replace the values with the ones that correspond to the actual scenario of your app based on the React component you are importing.
 
 1. Open your app's code (previously called `react-app-template`) in the code editor.
 2. In the `react` folder, create a new TypeScript file with the name of the desired React component. Following our example, we would have `HelloWorld.tsx`.
-3. Once you are in the file, add the sample code below (replacing the values to match your case):
+3. In the newly created file, add the sample code provided below:
 
 ```jsx
 import { React } from 'react'
@@ -64,11 +65,11 @@ const HelloWorld = () => <div>Hello, World!</div>
 export default HelloWorld
 ```
 
-> ℹ️ Read the [React solution](https://reactjs.org/docs/getting-started.html) and [Developing custom storefront components](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components) documentation to better understand how components work.
+> ℹ️ Read the [React documentation](https://reactjs.org/docs/getting-started.html) and [Developing custom storefront components](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components) documentation to better understand how React components work.
 
 4. Create a new folder called `store` in the first level of your app folders.
 5. In the `store` folder, add a new file called `interfaces.json`.
-6. Declare the component interface in the new file. For example:
+6. Declare the block interface in the `interfaces.json` file. For example:
 
 ```json
 {
@@ -80,41 +81,41 @@ export default HelloWorld
 
 Note that in the above structure, the first definition given by the interface is the name of your new theme block (`hello-world`). Within it, we declare an object containing the interface keys previously described.
 
-In our basic example, we only used the `component` key to link the`hello-world` block to the React component it will render (`HelloWorld`). Note that the value of the `component` key is `HelloWorld` — the file name that was previously created for the React component (`react / HelloWorld.tsx`).
+In our example, we only used the `component` key to link the`hello-world` block to the React component that it will render (`HelloWorld`). Note that the value of the `component` key is `HelloWorld` — the file name that was previously created for the React component (`react/HelloWorld.tsx`).
 
-> ℹ️ Be sure to check code from native Store Framework apps to learn more about structuring the `interfaces.json` file, such as [Search Result](https://github.com/vtex-apps/search-result/blob/master/store/interfaces.json) and [Header.](https://github.com/vtex-apps/store-header/blob/master/store/interfaces.json) Remember that how we declare an interface depends directly on the behavior we want for the new block. That is why, as we study different apps and blocks, we understand more the possibilities for interfaces.
+> ℹ️ To learn more about structuring the `interfaces.json` file, check the code of native Store Framework apps, such as [Search Result](https://github.com/vtex-apps/search-result/blob/master/store/interfaces.json) and [Header.](https://github.com/vtex-apps/store-header/blob/master/store/interfaces.json) Remember that how we declare an interface depends directly on the behavior we want for the new block. That is why, as we study different apps and blocks, we understand more the possibilities for interfaces.
 
 After saving your code changes, any user who installs your app will be ready to implement the new block.
 
-> ℹ️ If the app under development exports more than one theme block for rendering the React component, all the interfaces of these blocks must also be declared in the `interfaces.json` file, according to the above format.
+Note that, if the app under development exports more than one theme block for rendering the React component, all the interfaces of these blocks must also be declared in the `interfaces.json` file, according to the above format.
 
-### Declaring different interfaces by breakpoint
+### Declaring device-specific interfaces
 
 You may want your app to export different blocks for rendering different components based on the store's *breakpoint*, that is, based on the device accessing it.
 
-To do this, you have to create different blocks for each possible device and, consequently, create interfaces for each one.
+To do this, you have to create different blocks for each possible device and create interfaces for each one.
 
 For example, you are developing the `hello-world` block and want to create mobile and desktop versions. You will have to create the `HelloWorld`,`HelloWorldMobile`, and `HelloWorldDesktop` components, and define interfaces for each, such as `hello-world`, `hello-world.mobile`, and `hello-world.desktop`.
 
-The interface of the parent block `hello-world` has to contain only the `component` and `allowed` keys, the latter declaring the `hello-world.mobile` and `hello-world.desktop` blocks.
+The interface of the parent block, `hello-world`, has to contain only the `component` and `allowed` keys, with the `allowed` key declaring the `hello-world.mobile` and `hello-world.desktop` blocks.
 
-The interfaces for the last blocks, in turn, have to declare the desired keys to define the behavior of each block according to the device for which they were designed, such as the `device` key.
+The interfaces for the mobile and desktop blocks, in turn, have to declare the desired keys (e.g., `device`) to define the behavior of each block according to the device for which they were designed.
 
 App examples that use different React components for different devices are [Header](https://github.com/vtex-apps/store-header) and [Footer](https://github.com/vtex-apps/store-footer).
 
-## Using your new theme block
+## Step 2 - Using your new theme block
 
-We will now implement the new block you created.
+We will now implement the new block you created in the Store Theme app.
 
-If the VTEX account you are working on has the Store Theme app for VTEX Store Framework installed, follow the instructions below from step 2. If your account does not yet have the Store Theme app installed, follow the instructions from step 1:
+If the VTEX account you are working on has the Store Theme app for Store Framework installed, follow the instructions below from step 2. If your account does not yet have the Store Theme app installed, follow the instructions from step 1:
 
-1. Read carefully [step 3 in the Building stores with Store Framework section](https://developers.vtex.com/docs/guides/getting-started-3) and follow the steps detailed in the article. Once you are done, you will have implemented the standard theme for VTEX Store Framework and will be ready to test your new block.
+1. Read carefully [step 3 in the Building stores with Store Framework section](https://developers.vtex.com/docs/guides/getting-started-3) and follow the steps detailed in the article. Once you are done, you will have implemented the standard theme for Store Framework and will be ready to test your new block.
 2. Open the Store Theme app folder in your local files using the code editor of your choice.
-3. In the Store Theme `manifest.json` file, add the front app you are developing as a dependency in `dependencies`. For example:
+3. In the Store Theme `manifest.json` file, add the app you are developing as a dependency in `dependencies`. For example:
 
 ```diff
 "dependencies": {
-+   "yourVTEXAccountName.yourAppName": "0.x",
++   "{accountName}.{appName}": "{appVersion}",
     "vtex.store": "2.x",
     "vtex.store-header": "2.x",
     "vtex.product-summary": "2.x",
@@ -124,7 +125,7 @@ If the VTEX account you are working on has the Store Theme app for VTEX Store Fr
 }
 ```
 
-4. Then, add the new theme block (`hello-world` in our example) to one of the templates. For this walkthrough, we will add the `hello-world` block to the store's home page, in the `store.home` template:
+4. Add the new theme block (`hello-world` in our example) to one of the templates. For this walkthrough, we will add the `hello-world` block to the store's home page, in the `store.home` template:
 
 ```diff
 {
@@ -139,8 +140,8 @@ If the VTEX account you are working on has the Store Theme app for VTEX Store Fr
 
 5. [Link](https://developers.vtex.com/docs/guides/vtex-io-documentation-linking-an-app) the store's theme to the VTEX IO platform to verify the results:
 
-![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-0.png)
+  ![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-0.png)
 
-6. Access your VTEX store using the `{workspaceName}-{accountName}.myvtex.com` format to see your new `hello-world` block being displayed in your development *workspace*:
+6. Access your VTEX store using the `{workspaceName}-{accountName}.myvtex.com` format to see your new `hello-world` block being displayed in your development workspace:
 
-![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-1.png)
+  ![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-1.png)

--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developing-storefront-apps-using-react-and-vtex-io/vtex-io-documentation-4-declaring-a-theme-block.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developing-storefront-apps-using-react-and-vtex-io/vtex-io-documentation-4-declaring-a-theme-block.md
@@ -6,108 +6,115 @@ createdAt: "2021-03-25T20:58:43.073Z"
 updatedAt: "2022-12-13T20:17:44.349Z"
 category: "App Development"
 seeAlso:
- - "/docs/guides/vtex-io-documentation-5-defining-styles"
+  - "/docs/guides/vtex-io-documentation-5-defining-styles"
 ---
 
-With the app template already copied, we will now create a **new theme block**. Follow the instructions below to create the new theme block.
+With a copy of the app template, we will now create a **new theme block**. Follow the instructions below to create the new theme block.
 
-## Before you start
+## Before you begin
 
-- Before you start creating your storefront component, make sure you are familiar with the VTEX Store Framework and the concepts of blocks, store themes, and templates. If you need a refresher or are not yet familiar with these concepts, we highly recommend checking out the [Building storefronts with Store Framework](https://developers.vtex.com/docs/guides/getting-started-3) tutorial before proceeding. 
-- Check our recommended practices for tooling, features, flexibility, scalability, performance, accessibility, internationalization, and styling. For more information, please refer to [**Best practices for developing custom storefront components**](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components).
+1. You must be familiar with VTEX Store Framework and fully understand what a block, store theme, and template are. If you are not familiar with these concepts or want to refresh them before working on the settings, read [**Building stores with Store Framework**](https://developers.vtex.com/docs/guides/getting-started-3).
+
+2. When creating a storefront component, follow the best practices for tooling, features, flexibility, scalability, performance, accessibility, internationalization, and styling when creating your storefront component. Read [**Developing custom storefront components**](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components) to learn more.
 
 ## Understanding interfaces
 
-An interface describes the shape of an object, including its properties and data types. This is crucial for ensuring type safety and preventing potential bugs.
+An interface works as an API (*application programming interface*) that defines the theme blocks’ behavior following the React component they render.
 
-In VTEX Store Framework, interfaces are used to link theme blocks to their corresponding React components. This way, interfaces provide a set of rules that dictate the behavior of theme blocks when rendering their React components and the available properties and methods.
+In the same way that an API uses parameters to define how the conversation with a server will take place, the interface uses what we call *keys*.
 
-For each theme block exported by your app, you should define a corresponding [interface](https://developers.vtex.com/docs/guides/vtex-io-documentation-interface) that defines the props available to the React component. The table below lists some possible interface keys that you can add to your block's interface along with their respective descriptions.
+**The interfaces, using their keys, define a block's behavior when implementing and rendering in a store theme**.
 
-| Key           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `component`   | Name of the React component that the theme block will render.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `allowed`     | List of of other theme blocks that help build the desired React component. When declared, these blocks can be included as children to the block you developed in the Store Theme app.|
-| `composition` | Determines the rendering position of the children of the block that you are developing. Possible values for this key are `blocks` (the child blocks have a specific position in the interface, according to the React component on which they are based) or `children` (the position of the child blocks depends exclusively on how they are declared in the theme). If no value is defined for the `composition` key, the default is `blocks.` |
-| `device`      | Defines whether your theme block is designed for mobile or desktop devices. Possible values are `mobile` and `desktop`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `required`    | List of theme blocks that must be rendered in the interface to support the block rendering you are developing. |
-| `around`      | List of theme blocks that must be rendered in the interface around your new block for its correct functioning.|
-| `before`      | List of theme blocks that must be rendered in the interface before your block for its correct functioning. For example: `header`.|
-| `after`       | List of theme blocks that must be rendered in the interface after your block for its correct functioning. For example: `footer`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `preview`     | Defines the behavior of the page while the block is loaded.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `render`      | Defines the block's rendering type. Possible values are `lazy` (the block is only rendered when a user interacts with it), `server` (the block is rendered from the server side), or `client` (the block is rendered from the client side, that is, by the browser).|
+This means that, for each theme block exported by your app, you will need to define an [interface](https://developers.vtex.com/docs/guides/vtex-io-documentation-interface), which will link the block to the React component of your choice.
 
-The only mandatory key that needs to be declared in a block interface is `component`. 
+The following table shows some possible keys that could be added to the block interface, as well as their respective descriptions:
 
-## Step by step
+| Key           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`   | Name of the React component linked to the theme block. In other words, the name of the React component that the theme block will render.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `allowed`     | List of other theme blocks that, when declared, will help build the desired React component. In practice, blocks declared as `allowed` must be declared in the theme app (Store Theme) as children of the block you developed.                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `composition` | Defines whether the children of the block you are developing will have a specific rendering position in the interface. Remember that when defining the `composition` key, you don't control the position of the block it defines but the position of the children of that block. Possible values for this key are `blocks` (the child blocks have a specific position in the interface based on the React component on which they are based) or `children` (the position of the child blocks depends exclusively on how they are declared in the theme). If no value is defined for the `composition` key, the platform default is `blocks.` |
+| `device`      | Defines whether your theme block is designed for mobile or desktop devices. Possible values are `mobile` (designed for mobile devices) and `desktop` (designed for desktop devices).                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `required`    | List of theme blocks that must be rendered in the interface to support the block rendering you are developing.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `around`      | List of theme blocks that must be rendered in the interface around your new block for it to work correctly.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `before`      | List of theme blocks that must be rendered in the interface before your block (above it) for it to work correctly. For example: header.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `after`       | List of theme blocks that must be rendered in the interface after your block (below it) for it to work correctly. For example: footer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `preview`     | Defines the behavior of the page while the block is loading.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `render`      | Defines the block rendering type. Possible values are `lazy` (the block is only rendered when a user interacts with it), `server` (the block is rendered from the server side), or `client` (the block is rendered from the client side, by the browser).                                                                                                                                                                                                                                                                                                                                                                                    |
 
-### Step 1 - Declaring an interface
+The only mandatory key that needs to be declared in a block interface is `component`. You have to declare the other ones based on the desired scenario for your new theme block.
 
-To add new custom blocks to your VTEX store, you need to declare their interfaces in the interfaces.json file of your app. This file is used by [Store Builder](https://developers.vtex.com/docs/guides/vtex-io-documentation-builders/) during the website building process.
+## Declaring an interface
 
-As an example, let's create an interface for a basic block called `hello-world`. This block will render the React component defined in `HelloWorld.tsx`. 
+We declare the interface of one or more blocks in the app `interfaces.json` file, used by [Store Builder](https://developers.vtex.com/docs/guides/vtex-io-documentation-builders/) to correctly build your website's *frontend*.
 
-1. Open your app's code (previously called `react-app-template`) in your preferred code editor.
-2. In the `react` folder, create a new TypeScript file with the name of the desired React component. For example, `HelloWorld.tsx`.
-3. In the newly created file, add the sample code provided below:
+For this example, we will create an interface for a basic block called `hello-world` (based on the React `HelloWorld` component).
 
-  ```jsx
-  import { React } from 'react'
+When following these steps, remember to replace the values with the ones that correspond to the actual scenario of your app based on the React component you are importing.
 
-  const HelloWorld = () => <div>Hello, World!</div>
+1. Open your app's code (previously called `react-app-template`) in the code editor.
+2. In the `react` folder, create a new TypeScript file with the name of the desired React component. Following our example, we would have `HelloWorld.tsx`.
+3. Once you are in the file, add the sample code below (replacing the values to match your case):
 
-  export default HelloWorld
-  ```
+```jsx
+import { React } from 'react'
 
- > ℹ️ Refer to [React documentation](https://reactjs.org/docs/getting-started.html) and [Developing custom storefront components](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components) guide to learn more about how React components work.
+const HelloWorld = () => <div>Hello, World!</div>
 
-4. Create a new folder called `store` on the root level of your app's folders.
+export default HelloWorld
+```
+
+> ℹ️ Read the [React solution](https://reactjs.org/docs/getting-started.html) and [Developing custom storefront components](https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-custom-storefront-components) documentation to better understand how components work.
+
+4. Create a new folder called `store` in the first level of your app folders.
 5. In the `store` folder, add a new file called `interfaces.json`.
-6. Declare the block interface in the `interfaces.json` file. For example:
+6. Declare the component interface in the new file. For example:
 
- ```json
- {
-  "hello-world": {
-     "component": "HelloWorld"
-   }
- }
- ```
+```json
+{
+ "hello-world": {
+    "component": "HelloWorld"
+  }
+}
+```
 
-In this example, note that the first definition in the interface is the name of our new theme block, which is `hello-world`. Within it, we declare an object that contains the interface keys previously described.
+Note that in the above structure, the first definition given by the interface is the name of your new theme block (`hello-world`). Within it, we declare an object containing the interface keys previously described.
 
-In our example, we only used the `component` key to link the`hello-world` block to the React component that it will render, which is `HelloWorld`. Note that the value of the `component` key is `HelloWorld` – the file name that was previously created for the React component (`react/HelloWorld.tsx`).
+In our basic example, we only used the `component` key to link the`hello-world` block to the React component it will render (`HelloWorld`). Note that the value of the `component` key is `HelloWorld` — the file name that was previously created for the React component (`react / HelloWorld.tsx`).
 
-> ℹ️ To learn more about structuring the `interfaces.json` file, check the code of native Store Framework apps such as [Search Result](https://github.com/vtex-apps/search-result/blob/master/store/interfaces.json) and [Header](https://github.com/vtex-apps/store-header/blob/master/store/interfaces.json). Remember that the way we declare an interface depends directly on the behavior we want for the block.
+> ℹ️ Be sure to check code from native Store Framework apps to learn more about structuring the `interfaces.json` file, such as [Search Result](https://github.com/vtex-apps/search-result/blob/master/store/interfaces.json) and [Header.](https://github.com/vtex-apps/store-header/blob/master/store/interfaces.json) Remember that how we declare an interface depends directly on the behavior we want for the new block. That is why, as we study different apps and blocks, we understand more the possibilities for interfaces.
 
-After saving your code changes, your new block will be ready to be implemented by any user who installs your app.
+After saving your code changes, any user who installs your app will be ready to implement the new block.
 
-> ℹ️ If the app under development exports more than one theme block, all of these blocks' interfaces must also be declared in the `interfaces.json` file, according to the format presented in this section.
+> ℹ️ If the app under development exports more than one theme block for rendering the React component, all the interfaces of these blocks must also be declared in the `interfaces.json` file, according to the above format.
 
-#### Declaring device-specific interfaces
+### Declaring different interfaces by breakpoint
 
-In some cases, you may want your app to export different blocks to render different components depending on the device accessing the store. You can achieve this by creating different blocks for each possible device and defining different interfaces for each one of them
+You may want your app to export different blocks for rendering different components based on the store's *breakpoint*, that is, based on the device accessing it.
 
-Let's take an example where you are developing the `hello-world` block and want to create mobile and desktop versions for it. You will have to create the `HelloWorld`, `HelloWorldMobile`, and `HelloWorldDesktop` components, and define interfaces for each one of them, such as `hello-world`, `hello-world.mobile`, and `hello-world.desktop`.
+To do this, you have to create different blocks for each possible device and, consequently, create interfaces for each one.
 
-The parent block's interface (`hello-world`) should contain only the `component` and `allowed` keys, with the `allowed` key declaring the `hello-world.mobile` and `hello-world.desktop` blocks.
+For example, you are developing the `hello-world` block and want to create mobile and desktop versions. You will have to create the `HelloWorld`,`HelloWorldMobile`, and `HelloWorldDesktop` components, and define interfaces for each, such as `hello-world`, `hello-world.mobile`, and `hello-world.desktop`.
 
-The interfaces for the mobile and desktop blocks, in turn, should declare the desired keys, for example `device`, to define the behavior of each block according to the device for which they were designed.
+The interface of the parent block `hello-world` has to contain only the `component` and `allowed` keys, the latter declaring the `hello-world.mobile` and `hello-world.desktop` blocks.
 
-Apps like [Header](https://github.com/vtex-apps/store-header) and [Footer](https://github.com/vtex-apps/store-footer) are good examples that use different React components for different devices.
+The interfaces for the last blocks, in turn, have to declare the desired keys to define the behavior of each block according to the device for which they were designed, such as the `device` key.
 
-### Step 2 - Using your new theme block
+App examples that use different React components for different devices are [Header](https://github.com/vtex-apps/store-header) and [Footer](https://github.com/vtex-apps/store-footer).
 
-Now, it's time to implement the new block you created in a Store Theme app.
+## Using your new theme block
 
-If the Store Theme app for VTEX Store Framework is already installed in your VTEX account, follow the instructions below starting from step 2. If the app is not yet installed, follow the instructions from step 1:
+We will now implement the new block you created.
 
-1. Read carefully [step 3 in the Build stores with Store Framework section](https://developers.vtex.com/docs/guides/getting-started-3) and follow the steps detailed in the article. Once you are done, you will have implemented the standard theme for the VTEX Store Framework and will be ready to test your new block.
-2. Open the Store Theme app folder using the code editor of your choice.
-3. In the Store Theme `manifest.json` file, add the app you are developing as a dependency in `dependencies`. For example:
+If the VTEX account you are working on has the Store Theme app for VTEX Store Framework installed, follow the instructions below from step 2. If your account does not yet have the Store Theme app installed, follow the instructions from step 1:
+
+1. Read carefully [step 3 in the Building stores with Store Framework section](https://developers.vtex.com/docs/guides/getting-started-3) and follow the steps detailed in the article. Once you are done, you will have implemented the standard theme for VTEX Store Framework and will be ready to test your new block.
+2. Open the Store Theme app folder in your local files using the code editor of your choice.
+3. In the Store Theme `manifest.json` file, add the front app you are developing as a dependency in `dependencies`. For example:
 
 ```diff
 "dependencies": {
-+   "{accountName}.{appName}": "{appVersion}",
++   "yourVTEXAccountName.yourAppName": "0.x",
     "vtex.store": "2.x",
     "vtex.store-header": "2.x",
     "vtex.product-summary": "2.x",
@@ -130,10 +137,10 @@ If the Store Theme app for VTEX Store Framework is already installed in your VTE
 }
 ```
 
-5. [Link](https://developers.vtex.com/docs/guides/vtex-io-documentation-linking-an-app) the store's theme with the VTEX IO platform.
+5. [Link](https://developers.vtex.com/docs/guides/vtex-io-documentation-linking-an-app) the store's theme to the VTEX IO platform to verify the results:
 
- ![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-0.png)
+![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-0.png)
 
-6. Access your store using the structure `{workspaceName}-{accountName}.myvtex.com` to see your new `hello-world` block being displayed in your development workspace:
+6. Access your VTEX store using the `{workspaceName}-{accountName}.myvtex.com` format to see your new `hello-world` block being displayed in your development *workspace*:
 
 ![image](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/vtex-io-documentation-4-declaring-a-theme-block-1.png)


### PR DESCRIPTION
It relates to task [LOC-11451](https://vtex-dev.atlassian.net/browse/LOC-11451) and KR 23Q2-KR1 ([Review all developer portal documentation in English](https://docs.google.com/document/d/1VduAYpjqdazhyGH5DvD9c52pMu1Xfj4RDx48QNjTFU0/edit)).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [X] Spelling and grammar accuracy (self-explanatory)


[LOC-11451]: https://vtex-dev.atlassian.net/browse/LOC-11451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ