### PR TITLE
Fixes of i18n on vtex-io-documentation-5-writingtheheaderandbodyscripts.md

### DIFF
--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-5-writingtheheaderandbodyscripts.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-5-writingtheheaderandbodyscripts.md
@@ -4,7 +4,7 @@ slug: "vtex-io-documentation-5-writingtheheaderandbodyscripts"
 hidden: false
 category: "App Development"
 seeAlso:
-  - "/docs/guides/vtex-io-documentation-6-listeningtostoreevents"
+- "/docs/guides/vtex-io-documentation-6-listeningtostoreevents"
 createdAt: "2020-11-03T18:19:23.999Z"
 updatedAt: "2022-12-13T20:17:44.369Z"
 ---

--- a/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-5-writingtheheaderandbodyscripts.md
+++ b/docs/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-5-writingtheheaderandbodyscripts.md
@@ -4,21 +4,22 @@ slug: "vtex-io-documentation-5-writingtheheaderandbodyscripts"
 hidden: false
 category: "App Development"
 seeAlso:
- - "/docs/guides/vtex-io-documentation-6-listeningtostoreevents"
+  - "/docs/guides/vtex-io-documentation-6-listeningtostoreevents"
 createdAt: "2020-11-03T18:19:23.999Z"
 updatedAt: "2022-12-13T20:17:44.369Z"
 ---
+
 Now, it is time to define the scripts that your Pixel app will run on the store website. You can specify scripts that execute inside the `<header>` and/or `<body>` tags.
 
-Adding a script to the `<header>` ensures that it will be executed before any other HTML element is rendered on the page. Although this may harm your store's performance, it is a good option if your Pixel app relies on the interaction between users and the store components. On the other hand, adding a script to the store's `<body>` tag may not harm performance scores but at the cost of losing user data. Choose wisely according to your Pixel app functionality.
+Adding a script to the `<header>` ensures that it will be executed before any other HTML element is rendered on the page. Although this may affect store performance, it is a good option if your Pixel app relies on the interaction between users and store components. On the other hand, adding a script to the store `<body>` tag will probably reduce the impact on performance scores. However, this may come at the cost of losing user data. Choose wisely based on the functionality of your Pixel app.
 
-## Step by step
+## Instructions
 
 1. Open the `pixel/header.html` file and replace the provided function with your own.
 
-  > ℹ️ If you opt to execute your script inside the `<body>` tag, rename the `header.html` file to `body.html`.
+  > ℹ️ If you choose to execute your script inside the `<body>` tag, rename the `header.html` file to `body.html`.
 
-2. Use the `settingsSchema` identification key previously defined where applicable. Take the following example:
+2. Use the `settingsSchema` identification key previously defined where applicable. See the following example:
 
 ```html
 <script>


### PR DESCRIPTION
It relates to task [LOC-10770](https://vtex-dev.atlassian.net/browse/LOC-10770) and KR 23Q2-KR1 ([Review all developer portal documentation in English](https://docs.google.com/document/d/1VduAYpjqdazhyGH5DvD9c52pMu1Xfj4RDx48QNjTFU0/edit)).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [X] Spelling and grammar accuracy (self-explanatory)


[LOC-10770]: https://vtex-dev.atlassian.net/browse/LOC-10770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ