### PR TITLE
Fix some typos in the "A/B testing Legacy and IO store versions" guide

### DIFF
--- a/docs/vtex-io/App-Guides/ab-tests/vtex-io-documentation-performing-ab-testing-between-legacy-and-io.md
+++ b/docs/vtex-io/App-Guides/ab-tests/vtex-io-documentation-performing-ab-testing-between-legacy-and-io.md
@@ -31,13 +31,13 @@ vtex login {account-name}
 vtex use {workspace} 
 ```
 
-> ℹ️ Remember to replace the value between the brackets for the Development workspace you desire. For example: `vtex login test`.
+> ℹ️ Remember to replace the value between the brackets for the Development workspace you desire. For example: `vtex use test`.
 
-3. Run the `vtex use Master` command in your terminal to perform the steps below in the Master workspace. The Master workspace must be set to the `vtex.edition-business@0.x` [edition app](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app).
+3. Run the `vtex use master` command in your terminal to perform the steps below in the Master workspace. The Master workspace must be set to the `vtex.edition-business@0.x` [edition app](https://developers.vtex.com/docs/guides/vtex-io-documentation-edition-app).
 
 4. Install the `vtex.colossus-legacy-proxy@@1.8.9-hkignore` app. This is an essential step to avoid that you store in production break.
 
->⚠️ The app’s version must be `vtex.colossus-legacy-proxy@@1.8.9-hkignore`. If not, the store won’t respond to the request.
+>⚠️ The app’s version must be `vtex.colossus-legacy-proxy@1.8.9-hkignore`. If not, the store won’t respond to the request.
 
 5. [Open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759) requesting the redirection of the production workspace to be rendered in VTEX IO
 


### PR DESCRIPTION
https://developers.vtex.com/docs/guides/vtex-io-documentation-performing-ab-testing-between-legacy-and-io

I found some typos in this documentation while browsing it:

1. When `vtex use {workspace}` was demonstrated, the callout used an example for `vtex login`. I think we mean to give an example for `vtex use`.
2. Workspace names must all be lowercase, so `vtex use Master` should be `vtex use master`.
3. Remove an extra `@` in `vtex.colossus-legacy-proxy@@1.8.9-hkignore`. Not sure if it works with double `@`s, but normally only 1 is required.

<img width="998" alt="CleanShot 2023-07-24 at 13 29 59@2x" src="https://github.com/vtexdocs/dev-portal-content/assets/381395/9cca4299-d51c-4ca3-96dc-e4f03223b496">

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
