### PR TITLE
update orders overview callout about data retention

### DIFF
--- a/docs/guides/Getting-Started/orders-overview.md
+++ b/docs/guides/Getting-Started/orders-overview.md
@@ -91,7 +91,7 @@ Placing an order involves the Order Management module and [Checkout](https://dev
 
 ### Retrieving order’s details
 
-> You can only access information from orders created in the last two years, and that same period is valid for customers through [My Account](https://help.vtex.com/en/tutorial/how-my-account-works--2BQ3GiqhqGJTXsWVuio3Xh). To access order data from previous years, please contact [our Support](https://support.vtex.com/hc/en-us/requests). When granted by our Support, your access to orders placed before the last two years is temporary and will be available for 15 days.
+> You can only access information from orders created in the last two years, and that same period is valid for customers through [My Account](https://help.vtex.com/en/tutorial/how-my-account-works--2BQ3GiqhqGJTXsWVuio3Xh).
 
 You can fetch information about orders in multiple ways and about specific topics. To learn more about retrieving order content, see the links below.
 


### PR DESCRIPTION
Changed callout about data retention.

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

There was another change in the data retention policy for retrieving orders from more than 2 years ago. Now, it is no longer possible to open a ticket for support for data requests, because VTEX doesn't store that information anymore. In those endpoints, there was the same callout about this, and I have removed a sentence that said it was possible to open a ticket.