### PR TITLE
Fix: FastStore release note URL

### DIFF
--- a/docs/release-notes/2024-03-07-faststore-content-in-the-developer-portal.md
+++ b/docs/release-notes/2024-03-07-faststore-content-in-the-developer-portal.md
@@ -7,11 +7,11 @@ hidden: false
 excerpt: "After March 18, 2024, FastStore content moves to the Developer Portal."
 ---
 
-After March 18, 2024, all FastStore content currently available on the [FastStore Portal](htttps://faststore.dev) will be relocated and redirected to the [Developer Portal](https://developers.vtex.com).
+After March 18, 2024, all FastStore content currently available on the [FastStore Portal](https://www.faststore.dev/docs) will be relocated and redirected to the [Developer Portal](https://developers.vtex.com).
 
 ## What has changed?
 
-Currently, all FastStore content is in the [FastStore Portal](htttps://faststore.dev).
+Currently, all FastStore content is in the [FastStore Portal](https://www.faststore.dev/docs).
 To keep VTEX documentation centralized in one place and maintain a single source of truth, we are migrating the FastStore documentation to the Developer Portal.
 
 ## Why did we make this change?


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

This PR fixes the URLs to the FastStore portal mentioned in [the release note about content migration](https://developers.vtex.com/updates/release-notes/2024-03-07-faststore-content-in-the-developer-portal).