### PR TITLE
Chore: Migrating Headless CMS

### DIFF
--- a/docs/faststore/docs/headless-cms/3-adding-content-types-and-sections.mdx
+++ b/docs/faststore/docs/headless-cms/3-adding-content-types-and-sections.mdx
@@ -143,6 +143,7 @@ Depending on the `type` of your schema, you may need to define particular fields
 #### Using widgets
 
 When defining your Section `schema`, you can also use the [`uiSchema`](https://react-jsonschema-form.readthedocs.io/en/docs/api-reference/uiSchema/) along with [`widgets`](https://react-jsonschema-form.readthedocs.io/en/docs/usage/widgets/) to specify which UI widget should be used to render a given field of your schema. Common widgets are `draftjs-rich-text`, `image-uploader`, and `block-select`.
+Refer to the [Widgets](https://developers.vtex.com/docs/guides/faststore/headless-cms-widgets) guide for more information.
 
 {/* TODO: Check the following example of the `draftjs-rich-text` component being used. */}
 

--- a/docs/faststore/docs/headless-cms/widgets.mdx
+++ b/docs/faststore/docs/headless-cms/widgets.mdx
@@ -1,0 +1,16 @@
+# Widgets for CMS
+
+A widget is a graphical element that provides a particular way for editors to interact and upload content via the VTEX Headless CMS.
+
+Widgets may include date selectors, pull-down menus, buttons, selection boxes, progress indicators, and many other devices for displaying information andinviting, accepting, and responding to user actions.
+
+The list below shows the widgets you can use to integrate your storefront project with the VTEX Headless CMS Admin.
+
+| Name            | Description  | Implementation reference | Interface |
+| --------------- | ------------ | ------------------------ | --------- |
+| `Checkbox`      | Checkbox. | [`@material-ui/core/FormControlLabel`](https://mui.com/material-ui/api/form-control-label/#main-content) |![Checkbox](https://vtexhelp.vtexassets.com/assets/docs/src/Checkbox___cea741ccd6cca6538ae6b700feec9b13.png) |
+| `DateTime`      | Calendar popup for selecting a single date and time. | [VTEX Styleguide](https://styleguide.vtex.com/)| ![DateTime](https://vtexhelp.vtexassets.com/assets/docs/src/calendar___efa4e58e58e8869921237778f1aec6bc.png) |
+| `ImageUploader` | Image uploader for uploading or selecting an existing image from the media library.. | `react-resize-detector`, `react-dropzone` |![ImageUploader](https://vtexhelp.vtexassets.com/assets/docs/src/ImageUploader___ccaebbaf4c3892e7ddd8ed0ea16da51d.png) |
+| `RichText`      |  Rich text editor based on the `draft-js` library. | [Draft.js](https://github.com/facebook/draft-js) | ![RichText](https://vtexhelp.vtexassets.com/assets/docs/src/RichText___826b9e3ef1959c3fb33e4b5f437e9a5a.png) |
+| `Select`        | List of options to  select. | [`@material-ui/core/MenuItem`](https://mui.com/material-ui/api/menu-item/) | ![Select](https://vtexhelp.vtexassets.com/assets/docs/src/Select___b887b32d674f4ab96abedc9da1a37716.png) |
+| `Text`          | Input text editor. | [`@material-ui/core/InputLabel`](https://mui.com/material-ui/api/input-label/), [`@material-ui/core/FormHelperText`](https://mui.com/material-ui/api/form-helper-text/) | ![Text](https://vtexhelp.vtexassets.com/assets/docs/src/Text___7c1bca50c56ae574865416d43a0e607a.png) |

--- a/docs/faststore/docs/headless-cms/widgets.mdx
+++ b/docs/faststore/docs/headless-cms/widgets.mdx
@@ -1,6 +1,6 @@
-# Widgets for CMS
+# Widgets for Headless CMS
 
-A widget is a graphical element that provides a particular way for editors to interact and upload content via the VTEX Headless CMS.
+A widget is a graphical element that provides a particular way for editors to interact and upload content via the Headless CMS.
 
 Widgets may include date selectors, pull-down menus, buttons, selection boxes, progress indicators, and many other devices for displaying information andinviting, accepting, and responding to user actions.
 


### PR DESCRIPTION
#### Types of changes
- [x] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Migrating the Widgets documentation from FastStore v1 to FastStore v2

Updating navigation.json: https://github.com/vtexdocs/devportal/pull/610
