### PR TITLE
Chore: FastStore docs quick wins

### DIFF
--- a/docs/faststore/docs/customization/using-themes/overview.mdx
+++ b/docs/faststore/docs/customization/using-themes/overview.mdx
@@ -30,13 +30,13 @@ There are two types of design tokens: global tokens and local tokens.
 | **Global tokens** | Structural styles that define the behavior and design patterns of components at a system-wide level. They handle interactions such as showing or hiding dropdown menus and toggles. |
 | **Local tokens**  | Design tokens specific to individual components. They control the appearance of graphical elements within components, including typography, colors, borders, and spacing.           |
 
-By configuring both global and local tokens, you can create consistent visual styles across your application while allowing for customization at both the system and component levels.
+By configuring global and local tokens, you can create consistent visual styles across your application while allowing for customization at both the system and component levels.
 
 ---
 
 ## Brandless and the Theming structure
 
- **Brandless**, the FastStore default theme, is a themeable structure, made of two complementary layers:
+ **Brandless**, the FastStore default theme, is a themeable structure made of two complementary layers:
  a useful and assorted library of templates for the components and sections, the **Structural Styles**, alongside a comprehensive set of design tokens to further customize them, the **Theme Layer**.
 
 These two layers are the two main parts of the theming structure:
@@ -49,11 +49,11 @@ You have the flexibility to customize or override the styles defined in the Stru
 
 Understanding the Structural Styles and Theme layers enables you to create visually appealing and unique user interfaces while maintaining control and flexibility.
 
-![](https://vtexhelp.vtexassets.com/assets/docs/src/theming-intro___1d021c8548ba2338faba6dd2995bf7ce.png)
+![theming-architecture](https://vtexhelp.vtexassets.com/assets/docs/src/theming-intro___1d021c8548ba2338faba6dd2995bf7ce.png)
 
 ---
 
-## Theming Architecture
+## Theming architecture
 
 The theming architecture is structured as follows:
 
@@ -73,17 +73,17 @@ Local design tokens are connected to global tokens, forming the Theme. Global to
 
 </Steps>
 
-The interaction between components, local design tokens, and global design tokens creates a hierarchical structure that allows for modular theming and customization.
+The interaction between components, local design tokens, and global design tokens creates a hierarchical structure allowing modular theming and customization.
 
 ![](https://vtexhelp.vtexassets.com/assets/docs/src/theming-architecture___f965569346d8d7d6a3de1f020f06ac99.png)
 
 ---
 
-## Design Tokens Naming Scheme
+## Design Tokens naming scheme
 
 Design tokens follow a specific naming scheme to ensure predictability and cohesiveness. The naming scheme consists of different parts:
 
-- **Namespacing:** Indicates whether the token is a global or a component's local token.
+- **Namespacing:** Indicates the origin of the token. For example, in `--fs-color-main-0`, the `--f` indicates that the variable belongs to FastStore-related styles.
 
 - **Component:** Represents the semantic meaning of the token.
 

--- a/docs/faststore/docs/reference/project-structure/overview.mdx
+++ b/docs/faststore/docs/reference/project-structure/overview.mdx
@@ -56,11 +56,34 @@ For more information on configuration options for this file, refer to [Configura
 
 ### `package.json`
 
-Defines the project's metadata and handles dependencies and scripts using [Yarn](https://yarnpkg.com/migration/overview). Let's take a closer look at three important packages declared in this file:
+Defines the project's metadata and handles dependencies and scripts using [Yarn](https://yarnpkg.com/migration/overview). Let's take a closer look at five important packages declared in this file:
 
 #### `@faststore/core`
 
 Bundles FastStore source code, including the FatsStore starter: `starter store`. It contains four sub-packages, `Components`, `SDK`, `UI` and `API`, which handle the starter.
+
+#### `@faststore/sdk`
+
+Handles all meaningful states an ecommerce store might have, such as:
+
+| SDK states    | Description                                                                      |
+| ------------- | -------------------------------------------------------------------------------- |
+| **Session**   | Handles auth, region, locale, and currency data.                                 |
+| **Cart**      |  Handles a store cart's addition, remotion, update, and current state.           |
+| **Component** |  Handles the state of the components of a store (e.g., display/hide mini cart).  |
+| **Search**    | Handles the state of the faceted search (e.g., apply filters and sort).          |
+
+The SDKs also provide GA4-compatible analytics functions to help you create powerful analytics capabilities in your ecommerce.
+
+#### `@faststore/ui`
+
+Gathers the design system based on FastStore components, using [Sass](https://sass-lang.com/) for styling. For more information, refer to the [FastStore UI](https://developers.vtex.com/docs/guides/faststore/components-index) guide.
+
+> ℹ️ Although the components use [Sass](https://sass-lang.com/), you can work with the desired tool for styling.
+
+#### `@faststore/api`
+
+Connects your project to your favorite ecommerce provider by creating interfaces for querying products, collections, and handling carts.
 
 #### `@faststore/cli`
 

--- a/docs/faststore/docs/what-is-faststore.mdx
+++ b/docs/faststore/docs/what-is-faststore.mdx
@@ -29,42 +29,17 @@ Understand who's visiting your store and reach a higher organic traffic.
 
 </Steps>
 
----
-
 ## What is included?
 
-FastStore consists of three packages that enable the store to work: **FastStore Core**, **FastStore UI**, and **FastStore CLI**.
+FastStore consists of [five main packages](https://developers.vtex.com/docs/guides/faststore/project-structure-overview#packagejson) that enable the store to work: **FastStore Core**, **FastStore UI**, **FastStore SDK**, and **FastStore API** and **FastStore CLI**:
 
-### FastStore Core (@faststore/core)
-
-Provides the starter source code to get your store up and running. It contains three sub-packages: **Components, SDK, and API packages.**
-
-The `Components` package is a library that crafts the behavior of React components into data attributes. The SDK is an extensible state management library that handles all meaningful states an ecommerce store might have, such as:
-
-| SDK states    | Description                                                                      |
-| ------------- | -------------------------------------------------------------------------------- |
-| **Session**   | Handles auth, region, locale, and currency data.                                 |
-| **Cart**      |  Handles a store cart's addition, remotion, update, and current state.           |
-| **Component** |  Handles the state of the components of a store (e.g., display/hide mini cart).  |
-| **Search**    | Handles the state of the faceted search (e.g., apply filters and sort).          |
-
-Our SDKs also provide GA4-compatible analytics functions to help you create powerful analytics capabilities in your ecommerce.
-Finally, the API package lets you connect to your favorite ecommerce provider by creating interfaces for querying products, collections and manipulating carts.
-
-### FastStore UI (@faststore/ui)
-
-Gathers the design system based on FastStore components, using [Sass](https://sass-lang.com/) for styling. For more information, refer to the [FastStore UI](https://developers.vtex.com/docs/guides/faststore/components-index) guide.
-
-> ℹ️ Although the components use [Sass](https://sass-lang.com/), you can work with the desired tool for styling.
-
-### FastStore CLI (@faststore/cli)
-
-This package is responsible for unifying the VTEX source code, in `@faststore/core`, with the customizations and extensions the store will create in the `/src` folder.
-It makes debugging easier since we have this division between the VTEX source code and the customizations and extensions.
-
-FastStore never constrains developers to any proprietary framework. It is opinionated by default but flexible under the hood.
-
----
+| Package | Description |
+|---------| ------------|
+| Core | Provides the starter source code to get your store up and running. It contains four sub-packages: Components, SDK, UI, and API packages. |
+| UI | Gathers the design system based on FastStore components, using [Sass](https://sass-lang.com/) for styling. |
+| SDK | Provides developers with a set of tools that handle all meaningful states an ecommerce store might have, such as Session, Cart, Component, Search. |
+| API | Connects your project to your favorite ecommerce provider by creating interfaces for querying products and collections, as well as handling carts. |
+| CLI | unifies the VTEX source code in `@faststore/core` with the customizations and extensions the store will create in the `/src` folder. |
 
 ## What prior knowledge is required?
 
@@ -73,8 +48,6 @@ To follow along with this documentation, you should be familiar with web develop
 - [TypeScript](https://www.typescriptlang.org/)
 - [React](https://react.dev/)
 - [Next.js](https://nextjs.org/)
-
----
 
 ## What can you learn here?
 


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Improve the description of FS packages, fix the introductory part mentioning FS packages, and fix the namespacing in the themes docs. Related to the following feedback:
- [EDU-11745](https://vtex-dev.atlassian.net/browse/EDU-11745)
- [EDU-11696](https://vtex-dev.atlassian.net/browse/EDU-11696)


[EDU-11745]: https://vtex-dev.atlassian.net/browse/EDU-11745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-11696]: https://vtex-dev.atlassian.net/browse/EDU-11696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ