### PR TITLE
FastStore: Auth content acces

### DIFF
--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -4,6 +4,10 @@ title: 'Authenticated content'
 
 Authenticated content is a feature that restricts access to specific store content based on whether a user is logged in. This ensures that only registered and logged-in users can view exclusive content, like prices, detailed product descriptions, and special offers. Non-logged-in users will see generic content instead.
 
+| Before log in | After log in |
+| ------------- | ------------ |
+| ![auth-content-before-log-in](https://vtexhelp.vtexassets.com/assets/docs/src/before-login___1c428d5e4b755d2c94fb64968893290c.png) | ![auth-content-after-log-in](https://vtexhelp.vtexassets.com/assets/docs/src/after-login___de2dbeae277be2cae93ecc9ec51b3929.png) |
+
 Authenticated content fosters a more controlled and secure shopping environment for stores and customers, enhancing the shopping experience. For example, in B2B settings, this allows for customized access to product catalogs, ensuring that businesses only see relevant products and pricing. For segmented promotions, authenticated content enables merchants to tailor special offers and discounts to specific customer segments, increasing engagement and conversion rates.
 
 In this guide, learn how to create an authenticated component using the [Hero](https://developers.vtex.com/docs/guides/faststore/organisms-hero) component as an example.
@@ -62,9 +66,9 @@ Once you have chosen the component, you will need to override the component usin
 3. Open the terminal and run `yarn dev`.
 4. Access your store's local development URL (localhost). So far, you will have the following `Hero`:
 
-    ![]()
+    ![hero-before-log-in](https://vtexhelp.vtexassets.com/assets/docs/src/hero-component___d833f1abca8976e439c5d2e37ebda450.png)
 
-    At this point, the Hero component will not display an image, and logging in won't change that.
+At this point, the Hero component will not display an image, and logging in won't change that.
 
 ### Step 2 - Wrap the component with `ProfileChallenge`
 
@@ -107,7 +111,7 @@ The `ProfileChallenge` component checks if a user is logged in and has sales cha
 4. On the store home page, click on Sign in to enter your account.
 5. Once you are logged in, you will be able to see the customized Hero section:
 
-    ![]()
+    ![hero-auth-content](https://vtexhelp.vtexassets.com/assets/docs/src/hero-component-login___cb5cecfe909ff084771b45ae99eebc93.png)
 
 ### Step 3 - Create a component fallback
 
@@ -115,52 +119,61 @@ The `ProfileChallenge` has a property called `fallback`. This property allows yo
 
 1. To create a fallback component, open the override component file, in this case, `Hero.tsx`, and add the following:
 
-```tsx
-import { SectionOverride } from "@faststore/core";
-import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
+  ```tsx
+  import { SectionOverride } from "@faststore/core";
+  import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
 
-import { HeroHeader, HeroImage } from "@faststore/ui";
+  import { HeroHeader, HeroImage } from "@faststore/ui";
 
-const SECTION = "Hero" as const;
+  const SECTION = "Hero" as const;
 
-const override: SectionOverride = {
-  section: SECTION,
-  components: {
-    HeroImage: {
-      Component: (props) => (
-        <ProfileChallenge>
-          <HeroImage {...props} />
-        </ProfileChallenge>
-      ),
-    },
-    HeroHeader: {
-      Component: (props) => {
-        return (
-          <ProfileChallenge
-            fallback={
-              <HeroHeader
-                title="🔒 Auth Hero"
-                subtitle="You should be logged in to see this content"
-              />
-            }
-          >
-            <HeroHeader {...props} />
+  const override: SectionOverride = {
+    section: SECTION,
+    components: {
+      HeroImage: {
+        Component: (props) => (
+          <ProfileChallenge>
+            <HeroImage {...props} />
           </ProfileChallenge>
-        );
+        ),
+      },
+      HeroHeader: {
+        Component: (props) => {
+          return (
+            <ProfileChallenge
+              fallback={
+                <HeroHeader
+                  title="🔒 Auth Hero"
+                  subtitle="You should be logged in to see this content"
+                />
+              }
+            >
+              <HeroHeader {...props} />
+            </ProfileChallenge>
+          );
+        },
       },
     },
-  },
-};
+  };
 
-export { override };
+  export { override };
 
-```
-{EXPLICAR O EXEMPLO}
+  ```
+  - Inside the `components` section, specific components (`HeroImage` and `HeroHeader`) are targeted for customization.
+  - HeroImage Override:
+    - A new component function is defined that wraps the original `HeroImage` component with `ProfileChallenge`. This ensures `ProfileChallenge` logic is applied to `HeroImage`.
+  
+  - HeroHeader Override:
+    - A new component function is defined for `HeroHeader`.
+    - It uses `ProfileChallenge` with a `fallback` property.
+    - The `fallback` property defines what to display if the user isn't logged in.
+    - Inside the `fallback`, a custom `HeroHeader` component is created with two editable properties, title (`Auth Hero`), and subtitle (`You should be logged in to see this content`).
+    - If the user is logged in, the original `HeroHeader` content is displayed.
 
 2. Run `yarn dev` to sync the changes locally.
 3. Access the localhost available in the terminal, and without signing in to your account, you will see the following:
 
-    ![]()
+    ![hero-auth-content-before](https://vtexhelp.vtexassets.com/assets/docs/src/before-login___1c428d5e4b755d2c94fb64968893290c.png)
 
 ### Step 3 - Promoting your changes
 

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -9,18 +9,164 @@ Authenticated content fosters a more controlled and secure shopping environment 
 In this guide, learn how to create an authenticated component using the [Hero](https://developers.vtex.com/docs/guides/faststore/organisms-hero) component as an example.
 
 ## Before you begin
+
 ### Update the `@faststore/core` package
 
 Ensure your store is using `@faststore/core@v3.0.39` or later. To benefit from this feature, follow the steps below:
 
-Update your store’s `@faststore/core` package to the `v3.0.39` by running the following command:
+1. Update your store’s `@faststore/core` package to the `v3.0.39` by running the following command:
 
-```bash
-yarn add @faststore/core@3.0.39
-```
+    ```bash
+    yarn add @faststore/core@3.0.39
+    ```
 
-Run `yarn dev` to apply the changes to your project.
+2. Run `yarn dev` to apply the changes to your project.
 
 ### Understand Section Override
+
 Make sure you understand the concepts of [Section Override](https://developers.vtex.com/docs/guides/faststore/overrides-overview) to follow along.
+
 ## Step by step
+
+### Step 1 - Override a component
+
+Choose the component you want to restrict access to. To check the available components, refer to the [UI components](https://developers.vtex.com/docs/guides/faststore/components-index) guide.
+
+Once you have chosen the component, you will need to override the component using the feature [Section Override](https://developers.vtex.com/docs/guides/faststore/overrides-overview). In this guide we will use the [Hero](https://developers.vtex.com/docs/guides/faststore/organisms-hero) component as an example.
+
+1. In `src/components/overrides` create the `Hero.tsx` file.
+2. Add the following to the `Hero.tsx` file:
+
+    ```tsx
+    import { SectionOverride } from "@faststore/core";
+    import { HeroHeader, HeroImage } from "@faststore/ui";
+
+    const SECTION = "Hero" as const;
+
+    const override: SectionOverride = {
+    section: SECTION,
+    components: {
+        HeroImage: {
+        Component: (props) => (
+            <HeroImage {...props} />
+        ),
+        },
+    },
+    };
+
+    export { override };
+
+    ```
+	The code above overrides the `HeroImage` component to not show any images.
+
+3. Open the terminal and run `yarn dev`.
+4. Access your store's local development URL (localhost). So far, you will have the following `Hero`:
+
+    ![]()
+
+    At this point, the Hero component will not display an image, and logging in won't change that.
+
+### Step 2 - Wrap the component with `ProfileChallenge`
+
+The `ProfileChallenge` component checks if a user is logged in and has sales channel access. If both conditions are met, it displays your customized version (the overridden component). Otherwise, it displays the default Hero component or your [fallback component](#step-3-create-a-component-fallback-optional).
+
+1. In the `Hero.tsx` file, add the following code:
+
+    ```tsx
+    import { SectionOverride } from "@faststore/core";
+    import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
+
+    import { HeroHeader, HeroImage } from "@faststore/ui";
+
+    const SECTION = "Hero" as const;
+
+    const override: SectionOverride = {
+    section: SECTION,
+    components: {
+        HeroImage: {
+        Component: (props) => (
+            <ProfileChallenge>
+            <HeroImage {...props} />
+            </ProfileChallenge>
+        ),
+        },
+    },
+    };
+
+    export { override };
+    ```
+
+    - The code above imports the `ProfileChallenge` component.
+    - The `override` object defines the section (`Hero`) and the components to be overridden.
+    - Inside `components`, the `HeroImage` component is being overridden.
+    - The overridden `HeroImage` is wrapped with `ProfileChallenge`.
+    - When `ProfileChallenge` renders the `HeroImage`, it checks for user login status and sales channel access.
+
+2. Run `yarn dev` to sync the changes locally.
+3. To test the changes, access your store's local development URL (localhost). 
+4. On the store home page, click on Sign in to enter your account.
+5. Once you are logged in, you will be able to see the customized Hero section:
+
+    ![]()
+
+### Step 3 - Create a component fallback
+
+The `ProfileChallenge` has a property called `fallback`. This property allows you to display a custom component when a user is not logged in. If not provided, the default component with the original content will be displayed.
+
+1. To create a fallback component, open the override component file, in this case, `Hero.tsx`, and add the following:
+
+```tsx
+import { SectionOverride } from "@faststore/core";
+import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
+
+import { HeroHeader, HeroImage } from "@faststore/ui";
+
+const SECTION = "Hero" as const;
+
+const override: SectionOverride = {
+  section: SECTION,
+  components: {
+    HeroImage: {
+      Component: (props) => (
+        <ProfileChallenge>
+          <HeroImage {...props} />
+        </ProfileChallenge>
+      ),
+    },
+    HeroHeader: {
+      Component: (props) => {
+        return (
+          <ProfileChallenge
+            fallback={
+              <HeroHeader
+                title="🔒 Auth Hero"
+                subtitle="You should be logged in to see this content"
+              />
+            }
+          >
+            <HeroHeader {...props} />
+          </ProfileChallenge>
+        );
+      },
+    },
+  },
+};
+
+export { override };
+
+```
+{EXPLICAR O EXEMPLO}
+
+2. Run `yarn dev` to sync the changes locally.
+3. Access the localhost available in the terminal, and without signing in to your account, you will see the following:
+
+    ![]()
+
+### Step 3 - Promoting your changes
+
+After testing locally, you can promote your changes to production by doing the following:
+
+1. In your local store code, create a new branch with the changes you made.
+2. Push the changes to the new branch and publish it.
+3. Open a pull request in the store repository.
+4. If the checks and reviews are all good, merge the branch with the main one.

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -61,7 +61,8 @@ Once you have chosen the component, you will need to override the component usin
     export { override };
 
     ```
-	The code above overrides the `HeroImage` component to not show any images.
+
+   The code above overrides the `HeroImage` component to not show any images.
 
 3. Open the terminal and run `yarn dev`.
 4. Access your store's local development URL (localhost). So far, you will have the following `Hero`:
@@ -108,7 +109,7 @@ The `ProfileChallenge` component checks if a user is logged in and has sales cha
 
 2. Run `yarn dev` to sync the changes locally.
 3. To test the changes, access your store's local development URL (localhost). 
-4. On the store home page, click on Sign in to enter your account.
+4. On the store home page, click on **Sign in** to enter your account.
 5. Once you are logged in, you will be able to see the customized Hero section:
 
     ![hero-auth-content](https://vtexhelp.vtexassets.com/assets/docs/src/hero-component-login___cb5cecfe909ff084771b45ae99eebc93.png)
@@ -159,6 +160,7 @@ The `ProfileChallenge` has a property called `fallback`. This property allows yo
   export { override };
 
   ```
+
   - Inside the `components` section, specific components (`HeroImage` and `HeroHeader`) are targeted for customization.
   - HeroImage Override:
     - A new component function is defined that wraps the original `HeroImage` component with `ProfileChallenge`. This ensures `ProfileChallenge` logic is applied to `HeroImage`.

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -1,106 +1,26 @@
 ---
-title: "Authenticated Content Access"
-excerpt: "This feature allows the access control to ensure that only authenticated users can access content 
-ranging from product showcases, texts, links, banners, prices, etc., meeting the demand for security
-and customization."
+title: 'Authenticated content'
 ---
 
-## Overview
+Authenticated content is a feature that restricts access to specific store content based on whether a user is logged in. This ensures that only registered and logged-in users can view exclusive content, like prices, detailed product descriptions, and special offers. Non-logged-in users will see generic content instead.
 
-Authenticated Content Access is a crucial feature to enhance the user experience in online stores. 
-Before and after login, the user experience may differ, especially concerning accessible content 
-and prices. This functionality ensures that only authenticated users have access to certain content,
-such as prices, detailed product descriptions, and exclusive offers, while displaying generic 
-content for non-logged-in users. This not only increases user data security but also provides a 
-smoother and more transparent shopping experience. With Authenticated Content Access, online stores
-can offer a more controlled and secure environment for their customers, ensuring a satisfactory 
-shopping experience.
+Authenticated content fosters a more controlled and secure shopping environment for stores and customers, enhancing the shopping experience. For example, in B2B settings, this allows for customized access to product catalogs, ensuring that businesses only see relevant products and pricing. For segmented promotions, authenticated content enables merchants to tailor special offers and discounts to specific customer segments, increasing engagement and conversion rates.
 
----
+In this guide, learn how to create an authenticated component using the [Hero](https://developers.vtex.com/docs/guides/faststore/organisms-hero) component as an example.
 
-## Usage
+## Before you begin
+### Update the `@faststore/core` package
 
-> ⚠️  This feature is available starting from version 3.0.39 of the @faststore/core package.
+Ensure your store is using `@faststore/core@v3.0.39` or later. To benefit from this feature, follow the steps below:
 
+Update your store’s `@faststore/core` package to the `v3.0.39` by running the following command:
 
-<Steps>
-
-### Create a Override Component
-
-Override the component you wish to be visible only when the user is authenticated. 
-For further details, please refer to the [Overriding Native Components](/docs/building-sections/overriding-components-and-props) and Props section.
-
-### Wrapp the component with the ProfileChallenge
-
-The @faststore/core package exports the ProfileChallenge component. 
-This component takes a child as a prop. 
-The child will only be displayed if the user is logged in and has at least one 
-Sales Channel configured. For example:
-
-```tsx
-import { SectionOverride } from "@faststore/core";
-import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
-
-import { HeroHeader, HeroImage } from "@faststore/ui";
-
-const SECTION = "Hero" as const;
-
-const override: SectionOverride = {
-  section: SECTION,
-  components: {
-    HeroImage: {
-      Component: (props) => (
-        <ProfileChallenge>
-          <HeroImage {...props} />
-        </ProfileChallenge>
-      ),
-    },
-  },
-};
-
-export { override };
+```bash
+yarn add @faststore/core@3.0.39
 ```
 
-### Create a component Fallback (Optional)
+Run `yarn dev` to apply the changes to your project.
 
-The ```ProfileChallenge``` has a property called ```fallback```. This property is particularly useful when a 
-fallback component should be displayed when the user is not logged in. If the fallback is not 
-provided, nothing is displayed.
-
-```tsx
-import { SectionOverride } from "@faststore/core";
-import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
-
-import { HeroHeader, HeroImage } from "@faststore/ui";
-
-const SECTION = "Hero" as const;
-
-const override: SectionOverride = {
-  section: SECTION,
-  components: {
-    HeroHeader: {
-      Component: (props) => {
-        return (
-          <ProfileChallenge
-            fallback={
-              <HeroHeader
-                title="🔒 Auth Hero"
-                subtitle="You should be logged to see this content"
-              />
-            }
-          >
-            <HeroHeader {...props} />
-          </ProfileChallenge>
-        );
-      },
-    },
-  },
-};
-
-export { override };
-
-```
-
-</Steps>
-
----
+### Understand Section Override
+Make sure you understand the concepts of [Section Override](https://developers.vtex.com/docs/guides/faststore/overrides-overview) to follow along.
+## Step by step

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -1,17 +1,9 @@
 ---
-title: "Authenticated Content"
-excerpt: "This feature allows the access control to ensure that only authenticated users can access content"
----
-
-<header>
-
-# Authenticated Content Access
-
-This feature allows the access control to ensure that only authenticated users can access content 
+title: "Authenticated Content Access"
+excerpt: "This feature allows the access control to ensure that only authenticated users can access content 
 ranging from product showcases, texts, links, banners, prices, etc., meeting the demand for security
-and customization.
-
-</header>
+and customization."
+---
 
 ## Overview
 

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -1,0 +1,1 @@
+# Authenticated content access

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -1,1 +1,109 @@
-# Authenticated content access
+<header>
+
+# Authenticated Content Access
+
+This feature allows the access control to ensure that only authenticated users can access content 
+ranging from product showcases, texts, links, banners, prices, etc., meeting the demand for security
+and customization.
+
+</header>
+
+## Overview
+
+Authenticated Content Access is a crucial feature to enhance the user experience in online stores. 
+Before and after login, the user experience may differ, especially concerning accessible content 
+and prices. This functionality ensures that only authenticated users have access to certain content,
+such as prices, detailed product descriptions, and exclusive offers, while displaying generic 
+content for non-logged-in users. This not only increases user data security but also provides a 
+smoother and more transparent shopping experience. With Authenticated Content Access, online stores
+can offer a more controlled and secure environment for their customers, ensuring a satisfactory 
+shopping experience.
+
+---
+
+## Usage
+
+> ⚠️  This feature is available starting from version 3.0.39 of the @faststore/core package.
+
+
+<Steps>
+
+### Create a Override Component
+
+Override the component you wish to be visible only when the user is authenticated. 
+For further details, please refer to the [Overriding Native Components](/docs/building-sections/overriding-components-and-props) and Props section.
+
+### Wrapp the component with the ProfileChallenge
+
+The @faststore/core package exports the ProfileChallenge component. 
+This component takes a child as a prop. 
+The child will only be displayed if the user is logged in and has at least one 
+Sales Channel configured. For example:
+
+```tsx
+import { SectionOverride } from "@faststore/core";
+import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
+
+import { HeroHeader, HeroImage } from "@faststore/ui";
+
+const SECTION = "Hero" as const;
+
+const override: SectionOverride = {
+  section: SECTION,
+  components: {
+    HeroImage: {
+      Component: (props) => (
+        <ProfileChallenge>
+          <HeroImage {...props} />
+        </ProfileChallenge>
+      ),
+    },
+  },
+};
+
+export { override };
+```
+
+### Create a component Fallback (Optional)
+
+The ```ProfileChallenge``` has a property called ```fallback```. This property is particularly useful when a 
+fallback component should be displayed when the user is not logged in. If the fallback is not 
+provided, nothing is displayed.
+
+```tsx
+import { SectionOverride } from "@faststore/core";
+import { ProfileChallenge_unstable as ProfileChallenge } from "@faststore/core/experimental";
+
+import { HeroHeader, HeroImage } from "@faststore/ui";
+
+const SECTION = "Hero" as const;
+
+const override: SectionOverride = {
+  section: SECTION,
+  components: {
+    HeroHeader: {
+      Component: (props) => {
+        return (
+          <ProfileChallenge
+            fallback={
+              <HeroHeader
+                title="🔒 Auth Hero"
+                subtitle="You should be logged to see this content"
+              />
+            }
+          >
+            <HeroHeader {...props} />
+          </ProfileChallenge>
+        );
+      },
+    },
+  },
+};
+
+export { override };
+
+```
+
+</Steps>
+
+---

--- a/docs/faststore/components/features/auth-content.mdx
+++ b/docs/faststore/components/features/auth-content.mdx
@@ -1,3 +1,8 @@
+---
+title: "Authenticated Content"
+excerpt: "This feature allows the access control to ensure that only authenticated users can access content"
+---
+
 <header>
 
 # Authenticated Content Access

--- a/docs/faststore/components/features/overview.mdx
+++ b/docs/faststore/components/features/overview.mdx
@@ -29,11 +29,4 @@ related to store navigation and regionalization.
   linkTitle="See more"
   />
 
-  <WhatsNextCard
-  title="Authenticated Content Access"
-  description="Allows the access control to ensure that only authenticated users can access content."
-  linkTo="https://developers.vtex.com/docs/guides/faststore/features-auth-content"
-  linkTitle="See more"
-  />
-
 </Flex>

--- a/docs/faststore/components/features/overview.mdx
+++ b/docs/faststore/components/features/overview.mdx
@@ -29,4 +29,11 @@ related to store navigation and regionalization.
   linkTitle="See more"
   />
 
+  <WhatsNextCard
+  title="Authenticated Content Access"
+  description="Allows the access control to ensure that only authenticated users can access content."
+  linkTo="https://developers.vtex.com/docs/guides/faststore/features-auth-content"
+  linkTitle="See more"
+  />
+
 </Flex>


### PR DESCRIPTION
#### Types of changes
- [x] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

## What's the purpose of this pull request?

This PR adds the documentation about the Auth Content feature. It relates to the new initiative FastStore B2B. To learn more about this initiative, you can access the [Product Vision documentation](https://docs.google.com/document/d/17tJprtQEs9izw6Zh49thA90NuljoFLoMOyHwJvJAH1Q).

- PR editing the dev portal sidebar: https://github.com/vtexdocs/devportal/pull/660

- The feature PR is merged https://github.com/vtex/faststore/pull/2282

## References

[Feat: Add Auth Content feature #2282 Merged](https://github.com/vtex/faststore/pull/2282)
[Auth Content documentation](https://developers.vtex.com/docs/guides/faststore/features-auth-content)
[B2B Faststore Product Vision](https://docs.google.com/document/d/17tJprtQEs9izw6Zh49thA90NuljoFLoMOyHwJvJAH1Q/edit#heading=h.tglo77yl0lf)
[B2B Faststore RFC](https://docs.google.com/document/d/19jAFzUTJRhDSK5b6ieNigxDu5NnPC5gghPkMIaP6ic8/edit#heading=h.tglo77yl0lf)
[Auth Content RFC](https://docs.google.com/document/d/1mg1JzLphye8uvUtD_60cJGcvALyRWijpJ6sxEtuvmZM/edit#heading=h.tglo77yl0lf5)
[b2bfaststoredev](https://sfj-723d2df--b2bfaststoredev.preview.vtex.app/)
[PR](https://github.com/vtex-sites/b2bfaststoredev.store/pull/8)


## Related Tasks

[B2BTEAM-1594](https://vtex-dev.atlassian.net/browse/B2BTEAM-1594)
[ B2BTEAM-1591](https://vtex-dev.atlassian.net/browse/B2BTEAM-1591)
[B2BTEAM-1592](https://vtex-dev.atlassian.net/browse/B2BTEAM-1592)


[B2BTEAM-1594]: https://vtex-dev.atlassian.net/browse/B2BTEAM-1594
