### PR TITLE
EDU-11286: Section override (Part II - Unedited files)

### DIFF
--- a/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Migrating Overrides v1 to v2'
+title: 'Differences between Section Override v1 and v2'
 ---
 
-Section overrides v2, allow you to customize the appearance and functionality of existing components in your store. Compared to v1, Section overrides v2 offers an adaptable approach. We strongly recommend updating your customization methods to take advantage of these benefits.
+Section Override v2 allows you to customize the appearance and functionality of existing components in your store. Compared to v1, v2 offers an adaptable approach. We strongly recommend updating your customization methods to use Section Override v2 in your project.
 
-    > ⚠️ If you choose to continue using Overrides v1, please refer to the [Overriding components (v1)](https://developers.vtex.com/docs/guides/faststore/overrides-components-and-props-v1).
+    > ⚠️ If you choose to continue using Section Override v1, please refer to the [Overriding components (v1)](https://developers.vtex.com/docs/guides/faststore/overrides-components-and-props-v1).
 
 ## Main differences
 
@@ -16,38 +16,26 @@ Section overrides v2, allow you to customize the appearance and functionality of
 | Headless CMS property schema  | No customization, limited to native schemas.           | Customizable schema allowing definition of new properties.            |
 | Feature availability          | Experimental feature and may not function as expected. | Stable feature.                                                       |
 
+Check out the main differences related to the code syntax:
 
-## Step by step
-
-<Steps>
-
-### Update `@faststore/core` Package
-
-Ensure your store's `@faststore/core` package is version 3.x or higher to utilize Overrides v2. For update instructions, refer to the [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
-
-### Review existing overrides
-
-Identify all overrides currently implemented using Overrides v1 (refer to the [Overrides v1](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props) documentation). Once identified, you have the option to update these overrides to the latest version. For instructions on migrating overrides to v2, refer to the [Migrate overrides](#) section.
-
-If you wish to maintain existing v1 overrides alongside new v2 overrides, avoid modifying the v1-overridden components. Instead, create new overrides using v2, following the guide on [Overriding a component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
-
-### Migrate overrides
-
-Previously, in Section overrides v1, you passed the section name as a string to the `section` key within the `getOverriddenSection` method's overrides object. 
-Here's an example:
+- Previously, in Section Override v1, you passed the section name as a string to the `section` key within the `getOverriddenSection` method's overrides object:
 
     ```js
-    const NewAlert = getOverriddenSection({  
-    section: 'Alert',  
-    components: {  
-        Alert: { Component: CustomAlert },  
-    },  
-    });  
+    import { SectionOverride } from "@faststore/core";
 
-    export default NewAlert;  
+    const SECTION = "Alert" as const;
+
+    const override: SectionOverride = {
+        section: SECTION,
+        components: {
+            Alert: { Component: CustomAlert },  
+        },
+    };
+
+    export { override };
     ```
 
-Section overrides v2 introduces a clearer syntax. Now you import the section component (e.g., `AlertSection` from `@faststore/core`) and pass it to the `Section` key (uppercase `S`) within the overrides object. This emphasizes the component-based approach of v2.
+- Section Override v2 introduces a clearer syntax. Now you import the section component (e.g., `AlertSection` from `@faststore/core`) and pass it to the `Section` key (uppercase `S`) within the overrides object. This emphasizes the component-based approach of v2.
 
     ```js
     import { AlertSection, getOverriddenSection } from "@faststore/core";  
@@ -62,6 +50,14 @@ Section overrides v2 introduces a clearer syntax. Now you import the section com
     export default NewAlert;  
     ```
 
-After importing the section, ensure to synchronize your changes with the Headless CMS. Refer to the [Override a component prop](https://developers.vtex.com/docs/guides/faststore/component-props) or [Override a component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component) for instructions, from fixing the syntax to syncing the changes with Headless CMS.
+## Updating your project to Section Overrides v2
 
-</Steps>
+Make sure your store's `@faststore/core` package is version 3.0.0 or higher to work with Overrides v2. For update instructions, refer to the [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
+
+### Review existing overrides
+
+Identify all overrides currently implemented using Overrides v1 (refer to the [Overrides v1](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props) documentation). Once identified, you can keep these v1 overrides as they will continue to work in your project or create new ones using v2.
+
+    > ⚠️ We strongly recommend using Section Override v2 instead of Section Override v1.
+
+If you wish to maintain existing v1 overrides alongside new v2 overrides, avoid modifying the v1-overridden components. Instead, create new overrides using v2, following the guide on [Overriding a component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).

--- a/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
@@ -8,7 +8,7 @@ title: 'Upgrading from Section Override v1 to v2'
 
 ## Main differences
 
-| Feature                       | Section Override v1                                           | Section Overrides v2                                                          |
+| Feature                       | Section Override v1                                           | Section Override v2                                                          |
 | ----------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------- |
 | Overrides per section         | One override per section.                              | Multiple overrides per section.                                       |
 | Importing Section             | String passed to `section` key.                        | Section component imported and passed to `Section` key (uppercase S). |
@@ -56,8 +56,8 @@ Make sure your store's `@faststore/core` package is version 3.0.0 or higher to w
 
 ### Identify existing overrides (v1)
 
-Identify all overrides currently implemented using [Section Override v1]](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props). Once identified, you can keep these v1 overrides as they will continue to work in your project or create new ones using v2.
+Identify all overrides currently implemented using [Section Override v1](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props). Once identified, adjust your code to use [Section Override v2](https://developers.vtex.com/docs/guides/faststore/overrides-overview).
 
     > ⚠️ We strongly recommend using Section Override v2 instead of Section Override v1.
 
-If you wish to maintain existing v1 overrides alongside new v2 overrides, avoid modifying the v1-overridden components. Instead, create new overrides using v2, following the guide on [Overriding a component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
+

--- a/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
@@ -2,13 +2,13 @@
 title: 'Upgrading from Section Override v1 to v2'
 ---
 
-Section Override v2 allows you to customize the appearance and functionality of existing components in your store. Compared to v1, v2 offers an adaptable approach. We strongly recommend updating your customization methods to use Section Override v2 in your project.
+[Section Override v2](https://developers.vtex.com/docs/guides/faststore/overrides-overview) allows you to customize the appearance and functionality of existing components in your store. Compared to v1, v2 offers an adaptable approach. 
 
-    > ⚠️ If you choose to continue using Section Override v1, please refer to the [Overriding components (v1)](https://developers.vtex.com/docs/guides/faststore/overrides-components-and-props-v1).
+    > ⚠️ We strongly recommend using [Section Override v2](https://developers.vtex.com/docs/guides/faststore/overrides-overview) in favor of [Section Override v1](https://developers.vtex.com/docs/guides/faststore/overrides-components-and-props-v1).
 
 ## Main differences
 
-| Feature                       | Overrides v1                                           | Overrides v2                                                          |
+| Feature                       | Section Override v1                                           | Section Overrides v2                                                          |
 | ----------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------- |
 | Overrides per section         | One override per section.                              | Multiple overrides per section.                                       |
 | Importing Section             | String passed to `section` key.                        | Section component imported and passed to `Section` key (uppercase S). |
@@ -18,7 +18,7 @@ Section Override v2 allows you to customize the appearance and functionality of 
 
 Check out the main differences related to the code syntax:
 
-- Previously, in Section Override v1, you defined the override as an object with properties for the section name and component overrides:
+- In Section Override v1, a section is overridden by specifying the section name and component:
 
     ```js
     import { SectionOverride } from "@faststore/core";
@@ -56,7 +56,7 @@ Make sure your store's `@faststore/core` package is version 3.0.0 or higher to w
 
 ### Identify existing overrides (v1)
 
-Identify all overrides currently implemented using Overrides v1 (refer to the [Overrides v1](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props) documentation). Once identified, you can keep these v1 overrides as they will continue to work in your project or create new ones using v2.
+Identify all overrides currently implemented using [Section Override v1]](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props). Once identified, you can keep these v1 overrides as they will continue to work in your project or create new ones using v2.
 
     > ⚠️ We strongly recommend using Section Override v2 instead of Section Override v1.
 

--- a/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Differences between Section Override v1 and v2'
+title: 'Upgrading from Section Override v1 to v2'
 ---
 
 Section Override v2 allows you to customize the appearance and functionality of existing components in your store. Compared to v1, v2 offers an adaptable approach. We strongly recommend updating your customization methods to use Section Override v2 in your project.
@@ -18,7 +18,7 @@ Section Override v2 allows you to customize the appearance and functionality of 
 
 Check out the main differences related to the code syntax:
 
-- Previously, in Section Override v1, you passed the section name as a string to the `section` key within the `getOverriddenSection` method's overrides object:
+- Previously, in Section Override v1, you defined the override as an object with properties for the section name and component overrides:
 
     ```js
     import { SectionOverride } from "@faststore/core";
@@ -35,7 +35,7 @@ Check out the main differences related to the code syntax:
     export { override };
     ```
 
-- Section Override v2 introduces a clearer syntax. Now you import the section component (e.g., `AlertSection` from `@faststore/core`) and pass it to the `Section` key (uppercase `S`) within the overrides object. This emphasizes the component-based approach of v2.
+- Section Override v2 introduces a more component-centric approach. It directly references the section component (e.g., `AlertSection` from `@faststore/core`) using a dedicated function (`getOverriddenSection`) and builds the override object around it, emphasizing the component being overridden. This shift in v2 promotes clearer code and offers more control during the override creation process.
 
     ```js
     import { AlertSection, getOverriddenSection } from "@faststore/core";  
@@ -50,11 +50,11 @@ Check out the main differences related to the code syntax:
     export default NewAlert;  
     ```
 
-## Updating your project to Section Overrides v2
+## Updating your project to Section Override v2
 
-Make sure your store's `@faststore/core` package is version 3.0.0 or higher to work with Overrides v2. For update instructions, refer to the [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
+Make sure your store's `@faststore/core` package is version 3.0.0 or higher to work with Section Override v2. For update instructions, refer to the [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
 
-### Review existing overrides
+### Identify existing overrides (v1)
 
 Identify all overrides currently implemented using Overrides v1 (refer to the [Overrides v1](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props) documentation). Once identified, you can keep these v1 overrides as they will continue to work in your project or create new ones using v2.
 

--- a/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/migrating-v1-to-v2.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Migrating Overrides v1 to v2'
+---
+
+Section overrides v2, allow you to customize the appearance and functionality of existing components in your store. Compared to v1, Section overrides v2 offers an adaptable approach. We strongly recommend updating your customization methods to take advantage of these benefits.
+
+    > ⚠️ If you choose to continue using Overrides v1, please refer to the [Overriding components (v1)](https://developers.vtex.com/docs/guides/faststore/overrides-components-and-props-v1).
+
+## Main differences
+
+| Feature                       | Overrides v1                                           | Overrides v2                                                          |
+| ----------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------- |
+| Overrides per section         | One override per section.                              | Multiple overrides per section.                                       |
+| Importing Section             | String passed to `section` key.                        | Section component imported and passed to `Section` key (uppercase S). |
+| Native section                | The new component overrides the native one.            | The new component is based on the native one and can coexist with it. |
+| Headless CMS property schema  | No customization, limited to native schemas.           | Customizable schema allowing definition of new properties.            |
+| Feature availability          | Experimental feature and may not function as expected. | Stable feature.                                                       |
+
+
+## Step by step
+
+<Steps>
+
+### Update `@faststore/core` Package
+
+Ensure your store's `@faststore/core` package is version 3.x or higher to utilize Overrides v2. For update instructions, refer to the [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
+
+### Review existing overrides
+
+Identify all overrides currently implemented using Overrides v1 (refer to the [Overrides v1](https://developers.vtex.com/docs/guides/faststore/building-sections-overriding-components-and-props) documentation). Once identified, you have the option to update these overrides to the latest version. For instructions on migrating overrides to v2, refer to the [Migrate overrides](#) section.
+
+If you wish to maintain existing v1 overrides alongside new v2 overrides, avoid modifying the v1-overridden components. Instead, create new overrides using v2, following the guide on [Overriding a component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
+
+### Migrate overrides
+
+Previously, in Section overrides v1, you passed the section name as a string to the `section` key within the `getOverriddenSection` method's overrides object. 
+Here's an example:
+
+    ```js
+    const NewAlert = getOverriddenSection({  
+    section: 'Alert',  
+    components: {  
+        Alert: { Component: CustomAlert },  
+    },  
+    });  
+
+    export default NewAlert;  
+    ```
+
+Section overrides v2 introduces a clearer syntax. Now you import the section component (e.g., `AlertSection` from `@faststore/core`) and pass it to the `Section` key (uppercase `S`) within the overrides object. This emphasizes the component-based approach of v2.
+
+    ```js
+    import { AlertSection, getOverriddenSection } from "@faststore/core";  
+
+    const NewAlert = getOverriddenSection({ 
+    Section: AlertSection, 
+    components: {  
+        Alert: { Component: CustomAlert },  
+    }, 
+    });  
+
+    export default NewAlert;  
+    ```
+
+After importing the section, ensure to synchronize your changes with the Headless CMS. Refer to the [Override a component prop](https://developers.vtex.com/docs/guides/faststore/component-props) or [Override a component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component) for instructions, from fixing the syntax to syncing the changes with Headless CMS.
+
+</Steps>

--- a/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
@@ -197,7 +197,7 @@ To integrate the section into the [Headless CMS](https://developers.vtex.com/doc
 This schema Adds the new `Custom Buy Button` section to the Headless CMS.
 
 5. Open a new terminal window and log in to your VTEX account by running `vtex login {accountName}`.
-6. run the following command to sync your changes with the Headless CMS:
+6. Run the following command to sync your changes with the Headless CMS:
 
     ```bash
     yarn cms-sync
@@ -210,7 +210,7 @@ This schema Adds the new `Custom Buy Button` section to the Headless CMS.
 
 ### Step 4 - Visualizing the component on the page locally
 
-To see your changes locally you need to set the Headless CMS preview to the development mode. 
+To see your changes locally, set the Headless CMS preview to the development mode. 
 Refer to the [How to preview Headless CMS changes in development mode](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview-preview-changes-in-development-mode) guide for more information.
 
 Once you have set the preview for development mode, you should see your new Buy Button in a Product Details Page (PDP).

--- a/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
@@ -10,7 +10,7 @@ For example, you may want to replace the current `BuyButton` component from the 
 
 For this guide we will create a custom Buy Button that once you click on it, it displays an `alert` for the customer.
 
-    > ⚠️ Using overrides does not significantly impact performance. FastStore's handling of props and design tokens is designed for good performance. However, your customizations may introduce additional work, so consider overall store performance by checking Lighthouse reports on GitHub logs and Pull Requests.
+    > ⚠️ Using overrides does not significantly impact performance. FastStore's handling of props and design tokens is designed for good performance.
 
 ## Before you begin
 

--- a/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
@@ -2,11 +2,9 @@
 title: 'Overriding a native component'
 ---
 
-Now that you know how to [override a component's prop](LINK), learn how to override a native component to use a custom component.
+Now that you know how to [override a component's prop](https://developers.vtex.com/docs/guides/faststore/overrides-component-props), learn how to override a native component to use a custom component.
 
-For example, you may want to replace the current `BuyButton` component from the `ProductDetails` section to meet your business needs.
-
-Currently, when the [`BuyButton`](https://developers.vtex.com/docs/guides/faststore/molecules-buy-button) is clicked, it opens the `CartSideBar` as its default behavior:
+For example, you may want to replace the current `BuyButton` component from the `ProductDetails` section to meet your business needs. Currently, when the [`BuyButton`](https://developers.vtex.com/docs/guides/faststore/molecules-buy-button) is clicked, it opens the `CartSideBar` as its default behavior:
 
     ![overrides-PDP-buy-button-component](https://vtexhelp.vtexassets.com/assets/docs/src/overrides-buy-button-open-cart___a5853a88238fa31610a93e8a1333bb00.gif)
 
@@ -16,7 +14,7 @@ For this guide we will create a custom Buy Button that once you click on it, it 
 
 ## Before you begin
 
-Make sure your `@faststore/core` package has the 3.x version or above. If you need to update
+Make sure your `@faststore/core` package has the 3.0.0 version or above. If you need to update
 it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
 
 ## Step by step
@@ -33,7 +31,6 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
     </Tabs>
 
 3. In the `sections` folder, create a new file for your customized section. For example, create a new file named `ProductDetailsWithCustomButton.tsx` under the `src/components/sections` directory.
-
 4. Open the `ProductDetailsWithCustomButton.tsx` file and update it with the following code:
 
     ```tsx ProductDetailsWithCustomButton.tsx mark=8-9
@@ -53,7 +50,6 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
 
 1. Choose a component to override from the [list of overridable components of each native section](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections). 
 In this example, we are overriding the `BuyButton` component in the `ProductDetails` section.
-
 2. In the `components` folder, if you don't have already the `index.tsx` file, create the file and add the following:
 
     ```tsx components/index.tsx
@@ -63,16 +59,13 @@ In this example, we are overriding the `BuyButton` component in the `ProductDeta
 
     ```
 
-### Step 3 - Adding the component to the CMS
+### Step 3 - Adding the component to the Headless CMS
 
 To integrate the section into the [Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview), follow the steps below:
 
 1. Create a folder named `cms` in the FastStore root directory.
-
 2. Inside `cms`, create the `faststore` folder.
-
 3. Within the `cms/faststore` folder, create the `sections.json` file.
-
 4. Add the schema of the new section to the `sections.json` file, named `CustomBuyButton`, to the `sections.json` file:
 
     ```json sections.json
@@ -203,24 +196,17 @@ To integrate the section into the [Headless CMS](https://developers.vtex.com/doc
 
 This schema Adds the new `Custom Buy Button` section to the Headless CMS.
 
-5. Open a new terminal window and log in to your vtex account by running `vtex login {accountName}`.
-
+5. Open a new terminal window and log in to your VTEX account by running `vtex login {accountName}`.
 6. run the following command to sync your changes with the Headless CMS:
 
     ```bash
     yarn cms-sync
     ```
+
 7. Access the VTEX Admin and proceed to **Storefront > Headless CMS**.
-
 8. Click on the page you desire to add the new section.
-
 9. Click the add button (`+`) and add the new section and complete values from the sections fields.
-
 10. Click `Save`.
-
-    > ⚠️ Remember: props changed via Headless CMS overlap the changes made through [overrides](LINK).
-    For example, if you change a prop through override and also change it using
-    Headless CMS, the final prop's value will be the one added using CMS.
 
 ### Step 4 - Visualizing the component on the page locally
 

--- a/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/native-component.mdx
@@ -1,0 +1,238 @@
+---
+title: 'Overriding a native component'
+---
+
+Now that you know how to [override a component's prop](LINK), learn how to override a native component to use a custom component.
+
+For example, you may want to replace the current `BuyButton` component from the `ProductDetails` section to meet your business needs.
+
+Currently, when the [`BuyButton`](https://developers.vtex.com/docs/guides/faststore/molecules-buy-button) is clicked, it opens the `CartSideBar` as its default behavior:
+
+    ![overrides-PDP-buy-button-component](https://vtexhelp.vtexassets.com/assets/docs/src/overrides-buy-button-open-cart___a5853a88238fa31610a93e8a1333bb00.gif)
+
+For this guide we will create a custom Buy Button that once you click on it, it displays an `alert` for the customer.
+
+    > ⚠️ Using overrides does not significantly impact performance. FastStore's handling of props and design tokens is designed for good performance. However, your customizations may introduce additional work, so consider overall store performance by checking Lighthouse reports on GitHub logs and Pull Requests.
+
+## Before you begin
+
+Make sure your `@faststore/core` package has the 3.x version or above. If you need to update
+it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
+
+## Step by step
+### Step 1 - Setting up the component file
+
+1. After choosing a native section to be customized from the [list of available native sections](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections), open your FastStore project in any code editor of your preference.
+2. Go to the `src` folder, create the `components` folder, and inside it, create the `sections` folder. You can run the following command to create them:
+
+    > ℹ️ The naming of the `sections` folder is arbitrary, as overrides can be created in any file, since the import is made in the `src/components/index.tsx` file. 
+
+    <Tabs items={['macOS and Linux', 'Windows']}>
+        <Tab>```bash copy mkdir src/components src/components/sections ```</Tab>
+        <Tab>```bash copy mkdir src\components src\components\sections ```</Tab>
+    </Tabs>
+
+3. In the `sections` folder, create a new file for your customized section. For example, create a new file named `ProductDetailsWithCustomButton.tsx` under the `src/components/sections` directory.
+
+4. Open the `ProductDetailsWithCustomButton.tsx` file and update it with the following code:
+
+    ```tsx ProductDetailsWithCustomButton.tsx mark=8-9
+        import { ProductDetailsSection, getOverriddenSection } from '@faststore/core'
+
+        const ProductDetailsWithCustomButton = getOverriddenSection({
+        Section: ProductDetailsSection,
+        components: {
+            BuyButton: { Component: CustomBuyButton },
+        },
+        })
+
+        export default ProductDetailsWithCustomButton;
+    ```
+
+#### Step 2 - Overriding the component
+
+1. Choose a component to override from the [list of overridable components of each native section](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections). 
+In this example, we are overriding the `BuyButton` component in the `ProductDetails` section.
+
+2. In the `components` folder, if you don't have already the `index.tsx` file, create the file and add the following:
+
+    ```tsx components/index.tsx
+        import ProductDetailsWithCustomButton from "./sections/ProductDetailsWithCustomButton";
+
+        export default { ProductDetailsWithCustomButton };
+
+    ```
+
+### Step 3 - Adding the component to the CMS
+
+To integrate the section into the [Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview), follow the steps below:
+
+1. Create a folder named `cms` in the FastStore root directory.
+
+2. Inside `cms`, create the `faststore` folder.
+
+3. Within the `cms/faststore` folder, create the `sections.json` file.
+
+4. Add the schema of the new section to the `sections.json` file, named `CustomBuyButton`, to the `sections.json` file:
+
+    ```json sections.json
+    [
+        {
+            "name": "ProductDetailsWithCustomButton.tsx",
+            "requiredScopes": ["pdp"],
+            "schema": {
+            "title": "Custom Buy Button",
+            "description": "A new buy button to display an alert message.",
+            "type": "object",
+            "properties": {
+                "productTitle": {
+                "title": "Product Title",
+                "type": "object",
+                "properties": {
+                    "discountBadge": {
+                    "title": "Discount Badge",
+                    "type": "object",
+                    "properties": {
+                        "showDiscountBadge": {
+                        "title": "Show Discount Badge?",
+                        "type": "boolean",
+                        "default": false
+                        },
+                        "size": {
+                        "title": "Size",
+                        "type": "string",
+                        "enumNames": ["Big", "Small"],
+                        "enum": ["big", "small"]
+                        }
+                    }
+                    },
+                    "refNumber": {
+                    "title": "Show Reference Number?",
+                    "type": "boolean",
+                    "default": false
+                    }
+                }
+                },
+                "buyButton": {
+                "title": "Buy Button",
+                "type": "object",
+                "properties": {
+                    "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "default": "Add to Cart"
+                    },
+                    "customAlert": {
+                    "title": "Custom Alert Message",
+                    "type": "string",
+                    "default": "Customize your alert message here"
+                    }
+                }
+                },
+                "notAvailableButton": {
+                "title": "Not Available Button",
+                "description": "Shown when a SKU is not available",
+                "type": "object",
+                "properties": {
+                    "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "default": "Not Available"
+                    }
+                }
+                },
+                "shippingSimulator": {
+                "title": "Shipping Simulation",
+                "type": "object",
+                "properties": {
+                    "title": {
+                    "title": "Title",
+                    "type": "string",
+                    "default": "Shipping"
+                    },
+                    "inputLabel": {
+                    "title": "Input Label",
+                    "type": "string",
+                    "default": "Postal Code"
+                    },
+                    "link": {
+                    "title": "Postal Code Discovery",
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                        "title": "Link Text",
+                        "type": "string",
+                        "default": "I don't know my Postal Code"
+                        },
+                        "to": { "title": "URL", "type": "string" }
+                    }
+                    },
+                    "shippingOptionsTableTitle": {
+                    "title": "Shipping Options Table Header",
+                    "type": "string"
+                    }
+                }
+                },
+                "productDescription": {
+                "title": "Product Description",
+                "type": "object",
+                "properties": {
+                    "initiallyExpanded": {
+                    "type": "string",
+                    "title": "Initially Expanded?",
+                    "enumNames": ["First", "All", "None"],
+                    "enum": ["first", "all", "none"]
+                    },
+                    "displayDescription": {
+                    "title": "Should display description?",
+                    "type": "boolean",
+                    "default": true
+                    },
+                    "title": {
+                    "title": "Description section title",
+                    "type": "string",
+                    "default": "Description"
+                    }
+                }
+                }
+            }
+            }
+        }
+    ]
+    ```
+
+This schema Adds the new `Custom Buy Button` section to the Headless CMS.
+
+5. Open a new terminal window and log in to your vtex account by running `vtex login {accountName}`.
+
+6. run the following command to sync your changes with the Headless CMS:
+
+    ```bash
+    yarn cms-sync
+    ```
+7. Access the VTEX Admin and proceed to **Storefront > Headless CMS**.
+
+8. Click on the page you desire to add the new section.
+
+9. Click the add button (`+`) and add the new section and complete values from the sections fields.
+
+10. Click `Save`.
+
+    > ⚠️ Remember: props changed via Headless CMS overlap the changes made through [overrides](LINK).
+    For example, if you change a prop through override and also change it using
+    Headless CMS, the final prop's value will be the one added using CMS.
+
+### Step 4 - Visualizing the component on the page locally
+
+To see your changes locally you need to set the Headless CMS preview to the development mode. 
+Refer to the [How to preview Headless CMS changes in development mode](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview-preview-changes-in-development-mode) guide for more information.
+
+Once you have set the preview for development mode, you should see your new Buy Button in a Product Details Page (PDP).
+
+### Step 5 - Publishing your changes
+
+If your changes are working in the development mode and you want to publish them, follow the steps below:
+
+1. Go to the Headless CMS in the VTEX Admin.
+2. Click on a PDP page.
+3. Click `Publish` to make the new button available on the production store.


### PR DESCRIPTION
#### Types of changes
- [x] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

- Relates to #1111 
- `navigation.json` updated: [PR 646](https://github.com/vtexdocs/devportal/pull/646) 
- Jira task: [EDU-11286](https://vtex-dev.atlassian.net/browse/EDU-11286) 

[EDU-11286]: https://vtex-dev.atlassian.net/browse/EDU-11286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ