### PR TITLE
update checkout security guide url

### DIFF
--- a/docs/guides/Checkout/security.md
+++ b/docs/guides/Checkout/security.md
@@ -1,6 +1,6 @@
 ---
 title: "Security"
-slug: "security"
+slug: "checkout-security"
 hidden: false
 createdAt: "2022-10-20T17:32:48.440Z"
 updatedAt: "2022-10-20T17:32:48.440Z"


### PR DESCRIPTION
Changing the slug of a Checkout subcategory because we need the `security` slug for the Security guide that is part of 24H1KR3 (https://github.com/vtexdocs/dev-portal-content/pull/1169).

Related to https://github.com/vtexdocs/devportal/pull/666, where I adjusted navigation accordingly.

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
