### PR TITLE
Incident-844: Update 2-configuring-external-dns.mdx

### DIFF
--- a/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
+++ b/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
@@ -45,7 +45,7 @@ Now, you must set up your VTEX account to use the DNS records created in the pre
 5. Click `Add`.
 6. Add the `secure` subdomain (e.g., `secure.mystore.com`) to the list.
    ![host-configuration](https://vtexhelp.vtexassets.com/assets/docs/src/account-settings-new___2e13bee3041e8505922a737b94652ca6.png)
-7. Add the root domain as well; e.g., if your domain is `www.mysite.com,` add `mysite.com.` For a complete setup, you must add three hosts for each domain:
+7. Add the root domain as well; e.g., if your domain is `www.mystore.com`, add `mystore.com`. For a complete setup, you must add three hosts for each domain:
    - `www.mystore.com`  (store domain)
    - `mystore.com` (root domain)
    - `secure.mystore.com` (checkout/myaccount subdomain)

--- a/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
+++ b/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
@@ -50,7 +50,7 @@ Now, you must set up your VTEX account to use the DNS records created in the pre
    - `mysite.com` (root domain)
    - `secure.mysite.com` (checkout/myaccount subdomain)
 
-> ⚠️ To ensure a seamless checkout experience, all subdomains used by your store must be added to the host list. For instance, if your store uses another subdomain, such as `shop.mysite.com`, you need to register both `shop.mysite.com` and `mysite.com`. 
+> ⚠️ To ensure a seamless checkout experience, all subdomains used by your store must be added to the host list. In other words, you must include both the `www.` and non-`www.` domains in the hosts' list. Stores with custom prefixes, like `shop.mystore.com`, need both the prefix and main domain (`shop.mystore.com` and `mystore.com`) added. This guarantees that the checkout process works seamlessly when customers access the store with or without `www.` or any other custom prefix.
 
 8. Click the **Save** button.
 

--- a/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
+++ b/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
@@ -46,9 +46,9 @@ Now, you must set up your VTEX account to use the DNS records created in the pre
 6. Add the `secure` subdomain (e.g., `secure.mystore.com`) to the list.
    ![host-configuration](https://vtexhelp.vtexassets.com/assets/docs/src/account-settings-new___2e13bee3041e8505922a737b94652ca6.png)
 7. Add the root domain as well; e.g., if your domain is `www.mysite.com,` add `mysite.com.` For a complete setup, you must add three hosts for each domain:
-   - `www.mysite.com`  (store domain)
-   - `mysite.com` (root domain)
-   - `secure.mysite.com` (checkout/myaccount subdomain)
+   - `www.mystore.com`  (store domain)
+   - `mystore.com` (root domain)
+   - `secure.mystore.com` (checkout/myaccount subdomain)
 
 > ⚠️ To ensure a seamless checkout experience, all subdomains used by your store must be added to the host list. In other words, you must include both the `www.` and non-`www.` domains in the hosts' list. Stores with custom prefixes, like `shop.mystore.com`, need both the prefix and main domain (`shop.mystore.com` and `mystore.com`) added. This guarantees that the checkout process works seamlessly when customers access the store with or without `www.` or any other custom prefix.
 

--- a/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
+++ b/docs/faststore/docs/go-live/2-configuring-external-dns.mdx
@@ -41,13 +41,18 @@ Now, you must set up your VTEX account to use the DNS records created in the pre
 1. On VTEX Admin, click your profile avatar, which can be identified by the first letter of your email address.
 2. Access **Account Settings > Account**.
 3. Go to the **Stores** tab and in the **Hosts** table, click the menu (**⋮**) and choose **Edit**.
-4. In the **Hosts** field, enter your main domain (e.g., `mystore.com`) to the list.
+4. In the **Hosts** field, enter your main domain (e.g., `www.mystore.com`) to the list.
 5. Click `Add`.
 6. Add the `secure` subdomain (e.g., `secure.mystore.com`) to the list.
    ![host-configuration](https://vtexhelp.vtexassets.com/assets/docs/src/account-settings-new___2e13bee3041e8505922a737b94652ca6.png)
-7. Click the **Save** button.
+7. Add the root domain as well; e.g., if your domain is `www.mysite.com,` add `mysite.com.` For a complete setup, you must add three hosts for each domain:
+   - `www.mysite.com`  (store domain)
+   - `mysite.com` (root domain)
+   - `secure.mysite.com` (checkout/myaccount subdomain)
 
-> ⚠️ To ensure a seamless checkout experience, all subdomains used by your store must be added to the host list. If the store operates without the `www.` domain, you must include both the `www.` and non-`www.` domains in the hosts' list. Stores with custom prefixes, like `shop.mystore.com`, need both the prefix and main domain (`shop.mystore.com` and `mystore.com`) added. This guarantees that the checkout process works seamlessly when customers access the store with or without `www.` or any other custom prefix.
+> ⚠️ To ensure a seamless checkout experience, all subdomains used by your store must be added to the host list. For instance, if your store uses another subdomain, such as `shop.mysite.com`, you need to register both `shop.mysite.com` and `mysite.com`. 
+
+8. Click the **Save** button.
 
 ### Step 4 - Associating your custom domain with your FastStore project
 


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

To follow up on #inc-844, the documentation suggests only adding the hostname (without "www") to the list. This can confuse users, as the store actually operates using the "www" subdomain.
 This PR updates the documentation to clarify that both "www" and non-" "www" versions of the hostname should be added.
