### PR TITLE
chore: Remove temporarily `Build Webhook URL` info

### DIFF
--- a/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
+++ b/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
@@ -68,11 +68,8 @@ Now, check if the installation of the Headless CMS plugin was successful by runn
 Let's configure the URLs of the webhooks used by the Headless CMS app.
 
 1. In the VTEX Admin, access **Storefront > Headless CMS**. 
-2. In the FastStore project interface, click on `Settings`.
+2. In the FastStore project interface, click on `Settings` (⚙️).
 3. In **Settings**, click the `Build` tab.
-
-    ![cms-settings](https://vtexhelp.vtexassets.com/assets/docs/src/build-url___c220e60df37fbf4fc612eeebd4c90602.gif)
-
 4. Fill the **Preview URL** field with your production URL. This URL activates the button on Headless CMS so you can preview the changes made on a page. _Replace the values between curly brackets according to your scenario._
 
     ```sh

--- a/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
+++ b/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
@@ -73,18 +73,7 @@ Let's configure the URLs of the webhooks used by the Headless CMS app.
 
     ![cms-settings](https://vtexhelp.vtexassets.com/assets/docs/src/build-url___c220e60df37fbf4fc612eeebd4c90602.gif)
 
-4. In **Build Webhook URL**, click `Add`.
-5. In the field, enter the following value. _Replace the values between curly brackets according to your scenario._
-
-    ```sh
-    https://app.io.vtex.com/vtex.cms-builder-sf-jamstack/v1/{account}/{workspace}/build-releases
-    ```
-
-6. Click **SAVE**.
-
-    > ℹ️ When an editor clicks to publish a page using the Headless CMS interface, the CMS calls the **Build Webhook URL**, which changes the page's status to `published`. The CMS then waits for the content to be built in the background.
-
-7. Fill in the **Preview URL** field with your production URL. This URL activates the button on Headless CMS so you can preview the changes made on a page. _Replace the values between curly brackets according to your scenario._
+4. Fill the **Preview URL** field with your production URL. This URL activates the button on Headless CMS so you can preview the changes made on a page. _Replace the values between curly brackets according to your scenario._
 
     ```sh
     https://{account}.vtex.app/api/preview


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

The FastStore WebOps current state has a bug regarding the Headless CMS publishing process, which stores that set the `Build Webhook URL` field will cause timeout errors on the Releases-side. We should remove this info `temporarily` to avoid those situations while we are working in the Integrations API.