### PR TITLE
EDU-12592: Section override use cases

### DIFF
--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
@@ -105,36 +105,49 @@ By leveraging `getOverriddenSection`, you can create a custom component called `
 
 6. Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms).
 
-    The following schema was used as an example in [`cms/faststore/sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L58-L101):
+   The following schema was used as an example in [`cms/faststore/sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L58-L101):
 
     ```json
     [
-        {
+      {
         "name": "AlertWithImage",
         "schema": {
-        "title": "Alert with image",
-        "description": "Add an Alert that has an Image as an icon",
-        "type": "object",
-        "required": ["src", "content", "dismissible"],
-        "properties": {
+          "title": "Alert with image",
+          "description": "Add an Alert that has an Image as an icon",
+          "type": "object",
+          "required": [
+            "src",
+            "content",
+            "dismissible"
+          ],
+          "properties": {
             "src": {
-            "type": "string",
-            "title": "Image source",
-            "description": "Source of the Alert icon image"
+              "type": "string",
+              "title": "Image source",
+              "description": "Source of the Alert icon image"
             },
-            "content": { "type": "string", "title": "Content" },
+            "content": {
+              "type": "string",
+              "title": "Content"
+            },
             "link": {
-            "title": "Link",
-            "type": "object",
-            "properties": {
-                "text": { "type": "string", "title": "Link Text" },
-                "to": { "type": "string", "title": "Action link" }
-            }
+              "title": "Link",
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "title": "Link Text"
+                },
+                "to": {
+                  "type": "string",
+                  "title": "Action link"
+                }
+              }
             },
             "dismissible": {
-            "type": "boolean",
-            "default": false,
-            "title": "Is dismissible?"
+              "type": "boolean",
+              "default": false,
+              "title": "Is dismissible?"
             }
           }
         }

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
@@ -1,0 +1,151 @@
+---
+title: 'Adding an image to the Alert component'
+---
+
+This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the Alert section's icon to display an image instead. 
+
+> ℹ️ For detailed instructions on overriding components, refer to [Overriding native component’s props](https://developers.vtex.com/docs/guides/faststore/overrides-component-props) and [Overriding a native component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
+
+## Context
+
+- The native Alert section provides an `icon` prop for customization, but you want more control and flexibility over the displayed content.
+- You want to display a custom image alongside the text in your alert messages.
+
+## Implementation
+
+By leveraging `getOverriddenSection`, you can create a custom component called `AlertWithImage` that achieves the desired functionality. Follow the steps below:
+
+1. In the `src/components/sections` folder, create the folder `AlertWithImage` folder.
+2. In the `AlertWithImage` folder, create the `AlertWithImage.tsx` file.
+3. Import the following to the `AlertWithImage.tsx` file:
+
+    ```tsx
+    import { getOverriddenSection } from "@faststore/core";
+    import Image from "next/image";
+    import { useMemo } from "react";
+    ```
+
+4. Define the `AlertWithImageProps` interface:
+
+    ```tsx
+    interface AlertWithImageProps
+                    extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+                    src: string;
+                    alt: string;
+                }
+    ```
+
+   - This interface defines the props accepted by the `AlertWithImage` component.
+   - It inherits all props from the native Alert component, excluding the icon prop, which we intend to replace with an image.
+   - It adds a new prop named `src`, which specifies the image source URL.
+
+5. Create the `AlertWithImage` component:
+
+    ```tsx
+    import { useMemo } from "react";
+    import { AlertSection, getOverriddenSection } from "@faststore/core";
+    import { Image_unstable as Image } from "@faststore/core/experimental";
+
+
+    interface AlertWithImageProps
+        extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+        src: string;
+        alt: string;
+    }
+
+    export default function AlertWithImage(props: AlertWithImageProps) {
+        const { src, alt, ...otherProps } = props;
+
+        const OverriddenAlert = useMemo(
+            () =>
+            getOverriddenSection({
+                Section: AlertSection,
+                className: styles.alertWithImage,
+                components: {
+                    Icon: {
+                        Component: () => (
+                            <Image src={props.src} alt={props.alt} width={24} height={24} />
+                        ),
+                    },
+                },
+            }),
+        []
+    );
+
+    return <OverriddenAlert {...otherProps} icon="" />;
+    }
+    ```
+
+    - This function receives the `AlertWithImageProps`.
+    - It destructures the `src` prop containing the image source and remaining props using the spread operator (`...otherProps`).
+    - The core functionality lies within the `useMemo` hook.
+      - It defines the `OverriddenAlert` constant using `getOverriddenSection`.
+      - The override options specify:
+        - **`Section`:** The section to be overridden (Alert).
+        - **`components`:** An object containing the override for the Icon component.
+
+    - Inside the Icon override:
+      - **`Component`:** A function returning an `Image` component. This displays the image specified by the `src` prop.
+      - **`width`** and **`height`:** Optional props to set the size of the image.
+
+    - The use of `useMemo` ensures this override is only created once, improving performance.
+    - The function returns the `OverriddenAlert` component, spreading the `otherProps` and setting the `icon` prop to `noop` (effectively disabling the default icon behavior).
+
+    > ℹ️ For further details on code implementation, see the `AlertWithImage` folder available in the playground.store repository.
+
+6. Add the section to the Headless CMS by following the instructions available for sending components to the Headless CMS.
+
+The following schema was used as an example:
+
+    ```json 
+    [
+        {
+        "name": "AlertWithImage",
+        "schema": {
+        "title": "Alert with image",
+        "description": "Add an Alert that has an Image as an icon",
+        "type": "object",
+        "required": ["src", "content", "dismissible"],
+        "properties": {
+            "src": {
+            "type": "string",
+            "title": "Image source",
+            "description": "Source of the Alert icon image"
+            },
+            "content": { "type": "string", "title": "Content" },
+            "link": {
+            "title": "Link",
+            "type": "object",
+            "properties": {
+                "text": { "type": "string", "title": "Link Text" },
+                "to": { "type": "string", "title": "Action link" }
+            }
+            },
+            "dismissible": {
+            "type": "boolean",
+            "default": false,
+            "title": "Is dismissible?"
+            }
+        }
+        }
+    }
+    ]
+    ```
+
+> ℹ️ For further details on code implementation, see the `sections.json` file available in the playground.store repository.
+
+## Results
+
+Once you have [set your development mode](https://developers.vtex.com/docs/guides/faststore/headless-cms-previewing-changes-in-development-mode) to see the changes locally, you can see the image as an icon in the alert:
+
+- **Before**
+  
+  The native Alert displays one of the default icons, the `BellRinging`, following the sentence `Get 15% off today: NEW15! Buy now`.
+
+  ![before- alert-with-image](https://vtexhelp.vtexassets.com/assets/docs/src/before-custom-alert-image___fbd2316b0a78c7756fcc8523e7e6b181.png) 
+  
+- **After**
+  
+  The native Alert was replaced with the custom one, which features a pink image in the form of an icon added through Headless CMS.
+  
+  ![after - alert-with-image](https://vtexhelp.vtexassets.com/assets/docs/src/after-custom-alert-image___c4f735821a289a0fd0ce72947371e154.png)

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Adding an image to the Alert component'
+title: "Adding an image to the Alert component"
 ---
 
-This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert) section's icon to display a custom image as an icon instead. 
+This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert) section's icon to display a custom image as an icon instead.
 
 > ℹ️ For detailed instructions on overriding components, refer to [Overriding native component’s props](https://developers.vtex.com/docs/guides/faststore/overrides-component-props) and [Overriding a native component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
 
@@ -19,25 +19,25 @@ By leveraging `getOverriddenSection`, you can create a custom component called `
 2. In the `AlertWithImage` folder, create the `AlertWithImage.tsx` file.
 3. Import the following to the `AlertWithImage.tsx` file:
 
-    ```tsx
-    import { getOverriddenSection } from "@faststore/core";
-    import Image from "next/image";
-    import { useMemo } from "react";
-    ```
+   ```tsx
+   import { getOverriddenSection } from "@faststore/core";
+   import Image from "next/image";
+   import { useMemo } from "react";
+   ```
 
 4. Define the `AlertWithImageProps` interface:
 
-    ```tsx focus=5:9
-    import { getOverriddenSection } from "@faststore/core";
-    import Image from "next/image";
-    import { useMemo } from "react";
+   ```tsx focus=5:9
+   import { getOverriddenSection } from "@faststore/core";
+   import Image from "next/image";
+   import { useMemo } from "react";
 
-    interface AlertWithImageProps
-        extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
-        src: string;
-        alt: string;
-    }
-    ```
+   interface AlertWithImageProps
+     extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+     src: string;
+     alt: string;
+   }
+   ```
 
    - This interface defines the props accepted by the `AlertWithImage` component.
    - It inherits all props from the native Alert component, excluding the icon prop, which we intend to replace with an image.
@@ -45,62 +45,69 @@ By leveraging `getOverriddenSection`, you can create a custom component called `
 
 5. Create the `AlertWithImage` component:
 
-    ```tsx focus=10:31
-    import { useMemo } from "react";
-    import { AlertSection, getOverriddenSection } from "@faststore/core";
-    import { Image_unstable as Image } from "@faststore/core/experimental";
+   ```tsx focus=10:31
+   import { useMemo } from "react";
+   import { AlertSection, getOverriddenSection } from "@faststore/core";
+   import { Image_unstable as Image } from "@faststore/core/experimental";
 
-    interface AlertWithImageProps
-        extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
-        src: string;
-        alt: string;
-    }
+   interface AlertWithImageProps
+     extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+     src: string;
+     alt: string;
+   }
 
-    export default function AlertWithImage(props: AlertWithImageProps) {
-        const { src, alt, ...otherProps } = props;
+   export default function AlertWithImage(props: AlertWithImageProps) {
+     const { src, alt, ...otherProps } = props;
 
-        const OverriddenAlert = useMemo(
-            () =>
-            getOverriddenSection({
-                Section: AlertSection,
-                className: styles.alertWithImage,
-                components: {
-                    Icon: {
-                        Component: () => (
-                            <Image src={props.src} alt={props.alt} width={24} height={24} />
-                        ),
-                    },
-                },
-            }),
-        []
-    );
+     const OverriddenAlert = useMemo(
+       () =>
+         getOverriddenSection({
+           Section: AlertSection,
+           className: styles.alertWithImage,
+           components: {
+             Icon: {
+               Component: () => (
+                 <Image
+                   src={props.src}
+                   alt={props.alt}
+                   width={24}
+                   height={24}
+                 />
+               ),
+             },
+           },
+         }),
+       []
+     );
 
-    return <OverriddenAlert {...otherProps} icon="" />;
-    }
-    ```
+     return <OverriddenAlert {...otherProps} icon="" />;
+   }
+   ```
 
-    - This function receives the `AlertWithImageProps`.
-    - It destructures the `src` prop containing the image source and remaining props using the spread operator (`...otherProps`).
-    - The core functionality lies within the `useMemo` hook.
-      - It defines the `OverriddenAlert` constant using `getOverriddenSection`.
-      - The override options specify:
-        - **`Section`:** The section to be overridden (Alert).
-        - **`components`:** An object containing the override for the Icon component.
+   - This function receives the `AlertWithImageProps`.
+   - It destructures the `src` prop containing the image source and remaining props using the spread operator (`...otherProps`).
+   - The core functionality lies within the `useMemo` hook.
 
-    - Inside the Icon override:
-      - **`Component`:** A function returning an `Image` component. This displays the image specified by the `src` prop.
-      - **`width`** and **`height`:** Optional props to set the size of the image.
+     - It defines the `OverriddenAlert` constant using `getOverriddenSection`.
+     - The override options specify:
+       - **`Section`:** The section to be overridden (Alert).
+       - **`components`:** An object containing the override for the Icon component.
 
-    - The use of `useMemo` ensures this override is only created once, improving performance.
-    - The function returns the `OverriddenAlert` component, spreading the `otherProps` and setting the `icon` prop to `noop` (effectively disabling the default icon behavior).
+   - Inside the Icon override:
 
-    > ℹ️ For further details on code implementation, see the `AlertWithImage` folder available in the playground.store repository.
+     - **`Component`:** A function returning an `Image` component. This displays the image specified by the `src` prop.
+     - **`width`** and **`height`:** Optional props to set the size of the image.
 
-6. Add the section to the Headless CMS by following the instructions available for sending components to the Headless CMS.
+   - The use of `useMemo` ensures this override is only created once, improving performance.
+   - The function returns the `OverriddenAlert` component, spreading the `otherProps` and setting the `icon` prop to `noop` (effectively disabling the default icon behavior).
 
-The following schema was used as an example:
+   > ℹ️ For further details on code implementation, see the [`AlertWithImage`](https://github.com/vtex-sites/playground.store/tree/main/src/components/sections/AlertWithImage) folder available in the [playground.store](https://github.com/vtex-sites/playground.store) repository.
 
-    ```json 
+6. Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms).
+
+    The following schema was used as an example in [`cms/faststore/sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L58-L101):
+
+    ```json
     [
         {
         "name": "AlertWithImage",
@@ -135,20 +142,20 @@ The following schema was used as an example:
     ]
     ```
 
-> ℹ️ For further details on code implementation, see the `sections.json` file available in the playground.store repository.
+> ℹ️ For further details on code implementation, see the [`sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L58-L101) file available in the [playground.store](https://github.com/vtex-sites/playground.store/tree/main) repository.
 
 ## Results
 
 Once you have [set your development mode](https://developers.vtex.com/docs/guides/faststore/headless-cms-previewing-changes-in-development-mode) to see the changes locally, you can see the image as an icon in the alert:
 
 - **Before**
-  
+
   The native Alert displays one of the default icons, the `BellRinging`, following the sentence `Get 15% off today: NEW15! Buy now`.
 
-  ![before- alert-with-image](https://vtexhelp.vtexassets.com/assets/docs/src/before-custom-alert-image___fbd2316b0a78c7756fcc8523e7e6b181.png) 
-  
+  ![before- alert-with-image](https://vtexhelp.vtexassets.com/assets/docs/src/alert-default___12bbbaf326628380e71339c779d20f22.png)
+
 - **After**
-  
+
   The native Alert was replaced with the custom one, which features a pink image in the form of an icon added through Headless CMS.
-  
-  ![after - alert-with-image](https://vtexhelp.vtexassets.com/assets/docs/src/after-custom-alert-image___c4f735821a289a0fd0ce72947371e154.png)
+
+  ![after - alert-with-image](https://vtexhelp.vtexassets.com/assets/docs/src/alert-custom-image___0070f797fc5fdc69a5c6da983553868d.png)

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
@@ -25,7 +25,7 @@ By leveraging `getOverriddenSection`, you can create a custom component called `
     import { useMemo } from "react";
     ```
 
-4. Define the `AlertWithImageProps` interface (from line 5 to 9):
+4. Define the `AlertWithImageProps` interface:
 
     ```tsx focus=5:9
     import { getOverriddenSection } from "@faststore/core";
@@ -43,9 +43,9 @@ By leveraging `getOverriddenSection`, you can create a custom component called `
    - It inherits all props from the native Alert component, excluding the icon prop, which we intend to replace with an image.
    - It adds a new prop named `src`, which specifies the image source URL.
 
-5. Create the `AlertWithImage` component (from line 10 to 30):
+5. Create the `AlertWithImage` component:
 
-    ```tsx focus=10:20
+    ```tsx focus=10:31
     import { useMemo } from "react";
     import { AlertSection, getOverriddenSection } from "@faststore/core";
     import { Image_unstable as Image } from "@faststore/core/experimental";

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
@@ -2,13 +2,13 @@
 title: 'Adding an image to the Alert component'
 ---
 
-This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the Alert section's icon to display a custom image as an icon instead. 
+This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert) section's icon to display a custom image as an icon instead. 
 
 > ℹ️ For detailed instructions on overriding components, refer to [Overriding native component’s props](https://developers.vtex.com/docs/guides/faststore/overrides-component-props) and [Overriding a native component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
 
 ## Context
 
-- The native Alert section provides an `icon` prop for customization. It only accepts pre-defined icons, but you want more control and flexibility over the displayed content.
+- The native [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert) section provides an `icon` prop for customization. It only accepts predefined icons, but you want more control and flexibility over the displayed content.
 - You want to display a custom image as the icon alongside the text in your alert messages.
 
 ## Implementation

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-an-image-to-the-alert-component.mdx
@@ -2,14 +2,14 @@
 title: 'Adding an image to the Alert component'
 ---
 
-This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the Alert section's icon to display an image instead. 
+This guide illustrates an advanced use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the Alert section's icon to display a custom image as an icon instead. 
 
 > ℹ️ For detailed instructions on overriding components, refer to [Overriding native component’s props](https://developers.vtex.com/docs/guides/faststore/overrides-component-props) and [Overriding a native component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
 
 ## Context
 
-- The native Alert section provides an `icon` prop for customization, but you want more control and flexibility over the displayed content.
-- You want to display a custom image alongside the text in your alert messages.
+- The native Alert section provides an `icon` prop for customization. It only accepts pre-defined icons, but you want more control and flexibility over the displayed content.
+- You want to display a custom image as the icon alongside the text in your alert messages.
 
 ## Implementation
 
@@ -25,27 +25,30 @@ By leveraging `getOverriddenSection`, you can create a custom component called `
     import { useMemo } from "react";
     ```
 
-4. Define the `AlertWithImageProps` interface:
+4. Define the `AlertWithImageProps` interface (from line 5 to 9):
 
-    ```tsx
+    ```tsx focus=5:9
+    import { getOverriddenSection } from "@faststore/core";
+    import Image from "next/image";
+    import { useMemo } from "react";
+
     interface AlertWithImageProps
-                    extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
-                    src: string;
-                    alt: string;
-                }
+        extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+        src: string;
+        alt: string;
+    }
     ```
 
    - This interface defines the props accepted by the `AlertWithImage` component.
    - It inherits all props from the native Alert component, excluding the icon prop, which we intend to replace with an image.
    - It adds a new prop named `src`, which specifies the image source URL.
 
-5. Create the `AlertWithImage` component:
+5. Create the `AlertWithImage` component (from line 10 to 30):
 
-    ```tsx
+    ```tsx focus=10:20
     import { useMemo } from "react";
     import { AlertSection, getOverriddenSection } from "@faststore/core";
     import { Image_unstable as Image } from "@faststore/core/experimental";
-
 
     interface AlertWithImageProps
         extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
@@ -126,9 +129,9 @@ The following schema was used as an example:
             "default": false,
             "title": "Is dismissible?"
             }
+          }
         }
-        }
-    }
+      }
     ]
     ```
 

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -59,49 +59,51 @@ By leveraging `getOverriddenSection`, you can customize the Alert section's Head
 Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms). The following schema was used as an example:
 
         ```json
-        {
-        "name": "CustomIconsAlert",
-        "schema": {
-            "title": "Alert with more Icon options",
-            "description": "Add an alert that has more Icon options",
-            "type": "object",
-            "required": ["icon", "content", "dismissible"],
-            "properties": {
-            "icon": {
-                "type": "string",
-                "title": "Icon",
-                "enumNames": [
-                "Bell",
-                "BellRinging",
-                "Checked",
-                "Info",
-                "Truck",
-                "User",
-                "Plus",
-                "PlusCircle",
-                "Ruler",
-                "Star",
-                "Storefront",
-                "Twitter"
-                ],
-                "enum": [
-                "Bell",
-                "BellRinging",
-                "Checked",
-                "Info",
-                "Truck",
-                "User",
-                "Plus",
-                "PlusCircle",
-                "Ruler",
-                "Star",
-                "Storefront",
-                "Twitter"
-                ]
+        [    
+            {
+            "name": "CustomIconsAlert",
+            "schema": {
+                "title": "Alert with more Icon options",
+                "description": "Add an alert that has more Icon options",
+                "type": "object",
+                "required": ["icon", "content", "dismissible"],
+                "properties": {
+                "icon": {
+                    "type": "string",
+                    "title": "Icon",
+                    "enumNames": [
+                    "Bell",
+                    "BellRinging",
+                    "Checked",
+                    "Info",
+                    "Truck",
+                    "User",
+                    "Plus",
+                    "PlusCircle",
+                    "Ruler",
+                    "Star",
+                    "Storefront",
+                    "Twitter"
+                    ],
+                    "enum": [
+                    "Bell",
+                    "BellRinging",
+                    "Checked",
+                    "Info",
+                    "Truck",
+                    "User",
+                    "Plus",
+                    "PlusCircle",
+                    "Ruler",
+                    "Star",
+                    "Storefront",
+                    "Twitter"
+                    ]
+                  }
+                }
+              }
             }
-            }
-        }
-        }
+        ]
         ```
 
 > ℹ️ For further details on code implementation, see the [`sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L1-L55) file available in the [playground.store](https://github.com/vtex-sites/playground.store) repository.

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -49,14 +49,15 @@ By leveraging `getOverriddenSection`, you can customize the Alert section's Head
 
     - This is an Alert component override with custom icon options in the Headless CMS. The component is defined using `getOverriddenSection`.
     - This code changes only the schema to include more options for native Icons supported by `@faststore/ui`.
-    - The override options specify:
-      - **`Section`:** The section to be overridden (Alert).
+    - The override options specify the `Section` to be overridden (Alert).
 
     > ℹ️ For further details on code implementation, see the [`CustomIconsAlert`](https://github.com/vtex-sites/playground.store/tree/main/src/components/sections/CustomIconsAlert) folder available in the [playground.store](https://github.com/vtex-sites/playground.store) repository.
 
 ### Synchronizing the changes with the Headless CMS
 
-Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms). The following schema was used as an example:
+Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms).
+
+The following schema was used as an example:
 
         ```json
         [    

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Adding more icon options to the Alert component'
+title: "Adding more icon options to the Alert component"
 ---
 
 This guide illustrates a common use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the Headless CMS schema for a section to provide more icon options.
@@ -8,16 +8,16 @@ This guide illustrates a common use case for [`getOverriddenSection`](https://de
 
 ## Context
 
-- The native [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert ) section provides the following icon options by default:
+- The native [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert) section provides the following icon options by default:
 
-    | Alert default icon name | Icon                |
-    | ----------------------- | ------------------- |
-    | `Bell`                  | ![bell-icon](https://vtexhelp.vtexassets.com/assets/docs/src/bell-icon___78c462f54a529a5b68f696ebb9256e47.png) |
-    | `BellRinging`           | ![bell-ringing-icon](https://vtexhelp.vtexassets.com/assets/docs/src/bell-ringing-icon___ebaea6a1dfef58f1c76b14070703704b.png) |
-    | `Checked`               | ![checked-icon](https://vtexhelp.vtexassets.com/assets/docs/src/checked-icon___c4dc5aa336fca566ec361125a9eb846e.png) |
-    | `Info`                  | ![icon-info](https://vtexhelp.vtexassets.com/assets/docs/src/info-icon___f8c0cd591967892ec72328f277efa9d1.png) |
-    | `Truck`                 | ![truck-icon](https://vtexhelp.vtexassets.com/assets/docs/src/truck-icon___ec3a7f0fcf2c02580d49444b71e8fc36.png)   |
-    | `User`                  | ![user-icon](https://vtexhelp.vtexassets.com/assets/docs/src/user-icon___999dffa96120d0e51ead18263423ddad.png) |
+  | Alert default icon name | Icon                                                                                                                           |
+  | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+  | `Bell`                  | ![bell-icon](https://vtexhelp.vtexassets.com/assets/docs/src/bell-icon___78c462f54a529a5b68f696ebb9256e47.png)                 |
+  | `BellRinging`           | ![bell-ringing-icon](https://vtexhelp.vtexassets.com/assets/docs/src/bell-ringing-icon___ebaea6a1dfef58f1c76b14070703704b.png) |
+  | `Checked`               | ![checked-icon](https://vtexhelp.vtexassets.com/assets/docs/src/checked-icon___c4dc5aa336fca566ec361125a9eb846e.png)           |
+  | `Info`                  | ![icon-info](https://vtexhelp.vtexassets.com/assets/docs/src/info-icon___f8c0cd591967892ec72328f277efa9d1.png)                 |
+  | `Truck`                 | ![truck-icon](https://vtexhelp.vtexassets.com/assets/docs/src/truck-icon___ec3a7f0fcf2c02580d49444b71e8fc36.png)               |
+  | `User`                  | ![user-icon](https://vtexhelp.vtexassets.com/assets/docs/src/user-icon___999dffa96120d0e51ead18263423ddad.png)                 |
 
 - You want to allow Headless CMS editors to select in the Alert section from a wider range of icons supported by the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library.
 
@@ -27,15 +27,15 @@ This guide illustrates a common use case for [`getOverriddenSection`](https://de
 
 By leveraging `getOverriddenSection`, you can customize the Alert section's Headless CMS schema to offer additional icon options. Follow the steps below:
 
-1. In the `src/components/sections` folder, create the folder `CustomIconsAlert` folder.
-2. In the `CustomIconsAlert` folder, create the `CustomIconsAlert.tsx` file.
-3. Import the following to the `CustomIconsAlert.tsx` file:
+1.  In the `src/components/sections` folder, create the folder `CustomIconsAlert` folder.
+2.  In the `CustomIconsAlert` folder, create the `CustomIconsAlert.tsx` file.
+3.  Import the following to the `CustomIconsAlert.tsx` file:
 
         ```tsx
         import { getOverriddenSection } from '@faststore/core'
         ```
 
-4. Define the `CustomIconsAlert` component:
+4.  Define the `CustomIconsAlert` component:
 
         ```tsx focus=3:7
         import { AlertSection, getOverriddenSection } from '@faststore/core'
@@ -57,55 +57,55 @@ By leveraging `getOverriddenSection`, you can customize the Alert section's Head
 
 Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms).
 
-The following schema was used as an example:
+The following schema was used as an example in [`cms/faststore/sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L2-L57):
 
-        ```json
-        [    
-            {
-            "name": "CustomIconsAlert",
-            "schema": {
-                "title": "Alert with more Icon options",
-                "description": "Add an alert that has more Icon options",
-                "type": "object",
-                "required": ["icon", "content", "dismissible"],
-                "properties": {
-                "icon": {
-                    "type": "string",
-                    "title": "Icon",
-                    "enumNames": [
-                    "Bell",
-                    "BellRinging",
-                    "Checked",
-                    "Info",
-                    "Truck",
-                    "User",
-                    "Plus",
-                    "PlusCircle",
-                    "Ruler",
-                    "Star",
-                    "Storefront",
-                    "Twitter"
-                    ],
-                    "enum": [
-                    "Bell",
-                    "BellRinging",
-                    "Checked",
-                    "Info",
-                    "Truck",
-                    "User",
-                    "Plus",
-                    "PlusCircle",
-                    "Ruler",
-                    "Star",
-                    "Storefront",
-                    "Twitter"
-                    ]
-                  }
-                }
-              }
-            }
-        ]
-        ```
+```json
+[
+  {
+    "name": "CustomIconsAlert",
+    "schema": {
+      "title": "Alert with more Icon options",
+      "description": "Add an alert that has more Icon options",
+      "type": "object",
+      "required": ["icon", "content", "dismissible"],
+      "properties": {
+        "icon": {
+          "type": "string",
+          "title": "Icon",
+          "enumNames": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Plus",
+            "PlusCircle",
+            "Ruler",
+            "Star",
+            "Storefront",
+            "Twitter"
+          ],
+          "enum": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Plus",
+            "PlusCircle",
+            "Ruler",
+            "Star",
+            "Storefront",
+            "Twitter"
+          ]
+        }
+      }
+    }
+  }
+]
+```
 
 > ℹ️ For further details on code implementation, see the [`sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L1-L55) file available in the [playground.store](https://github.com/vtex-sites/playground.store) repository.
 
@@ -115,12 +115,12 @@ Once you have [set your development mode](https://developers.vtex.com/docs/guide
 
 - **Before**
 
-    The native Alert displays one of the default icons, `BellRinging`, alongside the text `Get 15% off today: NEW15! Buy now`.
+  The native Alert displays one of the default icons, `BellRinging`, alongside the text `Get 15% off today: NEW15! Buy now`.
 
-    ![before-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/before-alert-icon___86e395e9cfc731f1f70b56cf3760af08.png)
+  ![before-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/alert-default___12bbbaf326628380e71339c779d20f22.png)
 
 - **After**
-  
-    The native Alert was replaced with the custom one, which brings a new icon, `Star`, from the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library, alongside the text `Rate your favorite item`.
 
-    ![after-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/after-custom-alert-icon___87cd248c0c406640aaaac4ef9238e101.png)
+  The native Alert was replaced with the custom one, which brings a new icon, `Star`, from the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library, alongside the text `Rate your favorite item`.
+
+  ![after-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/alert-custom-icon___8a316b6e33417b6fda47a37c44f6b953.png)

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -1,0 +1,123 @@
+---
+title: 'Adding more icon options to the Alert component'
+---
+
+This guide illustrates a common use case for [`getOverriddenSection`](https://developers.vtex.com/docs/guides/faststore/overrides-getoverriddensection-function) in FastStore. It focuses on customizing the Headless CMS schema for a section to provide more icon options.
+
+> ℹ️ For detailed instructions on overriding components, refer to [Overriding native component’s props](https://developers.vtex.com/docs/guides/faststore/overrides-component-props) and [Overriding a native component](https://developers.vtex.com/docs/guides/faststore/overrides-native-component).
+
+## Context
+
+- The native [Alert](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections#alert ) section provides the following icon options by default:
+
+    | Alert default icon name | Icon                |
+    | ----------------------- | ------------------- |
+    | `Bell`                  | ![bell-icon](https://vtexhelp.vtexassets.com/assets/docs/src/bell-icon___78c462f54a529a5b68f696ebb9256e47.png) |
+    | `BellRinging`           | ![bell-ringing-icon](https://vtexhelp.vtexassets.com/assets/docs/src/bell-ringing-icon___ebaea6a1dfef58f1c76b14070703704b.png) |
+    | `Checked`               | ![checked-icon](https://vtexhelp.vtexassets.com/assets/docs/src/checked-icon___c4dc5aa336fca566ec361125a9eb846e.png) |
+    | `Info`                  | ![icon-info](https://vtexhelp.vtexassets.com/assets/docs/src/info-icon___f8c0cd591967892ec72328f277efa9d1.png) |
+    | `Truck`                 | ![truck-icon](https://vtexhelp.vtexassets.com/assets/docs/src/truck-icon___ec3a7f0fcf2c02580d49444b71e8fc36.png)   |
+    | `User`                  | ![user-icon](https://vtexhelp.vtexassets.com/assets/docs/src/user-icon___999dffa96120d0e51ead18263423ddad.png) |
+
+- You want to allow Headless CMS editors to select in the Alert section from a wider range of icons supported by the `@faststore/ui` [iconography library](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage).
+
+## Implementation
+
+### Overriding the Alert section
+
+By leveraging `getOverriddenSection`, you can customize the Alert section's Headless CMS schema to offer additional icon options. Follow the steps below:
+
+1. In the `src/components/sections` folder, create the folder `CustomIconsAlert` folder.
+2. In the `CustomIconsAlert` folder, create the `CustomIconsAlert.tsx` file.
+3. Import the following to the `CustomIconsAlert.tsx` file:
+
+        ```tsx
+        import { getOverriddenSection } from '@faststore/core'
+        ```
+
+4. Define the `CustomIconsAlert` component:
+
+        ```tsx
+        import { AlertSection, getOverriddenSection } from '@faststore/core'
+
+        const CustomIconsAlert = getOverriddenSection({
+        Section: AlertSection,
+        })
+
+        export default CustomIconsAlert
+        ```
+
+    - This is an Alert component override with custom icon options in the Headless CMS. The component is defined using `getOverriddenSection`.
+    - This code changes only the schema to include more options for native Icons supported by `@faststore/ui`.
+    - The override options specify:
+      - **`Section`:** The section to be overridden (Alert).
+
+    > ℹ️ For further details on code implementation, see the `CustomIconsAlert` folder available in the playground.store repository.
+
+### Synchronizing the changes with the Headless CMS
+
+Add the section to the Headless CMS by following the instructions available in [Sending components to the Headless CMS](https://developers.vtex.com/docs/guides/building-sections/overrides/sending-components-to-the-headless-cms). The following schema was used as an example:
+
+        ```json
+        {
+        "name": "CustomIconsAlert",
+        "schema": {
+            "title": "Alert with more Icon options",
+            "description": "Add an alert that has more Icon options",
+            "type": "object",
+            "required": ["icon", "content", "dismissible"],
+            "properties": {
+            "icon": {
+                "type": "string",
+                "title": "Icon",
+                "enumNames": [
+                "Bell",
+                "BellRinging",
+                "Checked",
+                "Info",
+                "Truck",
+                "User",
+                "Plus",
+                "PlusCircle",
+                "Ruler",
+                "Star",
+                "Storefront",
+                "Twitter"
+                ],
+                "enum": [
+                "Bell",
+                "BellRinging",
+                "Checked",
+                "Info",
+                "Truck",
+                "User",
+                "Plus",
+                "PlusCircle",
+                "Ruler",
+                "Star",
+                "Storefront",
+                "Twitter"
+                ]
+            }
+            }
+        }
+        }
+        ```
+
+> ℹ️ For further details on code implementation, see the `sections.json` file available in the playground.store repository.
+
+## Results
+
+Once you have [set your development mode](https://developers.vtex.com/docs/guides/building-sections/overrides/sending-components-to-the-headless-cms#previewing-changes-in-the-development-mode) to see the changes locally, you can see the new Alert icon. Below, you can check an example storefront before and after the instructions in this guide:
+
+- **Before**
+
+    The native Alert displays one of the default icons, the `BellRinging`, following the sentence `Get 15% off today: NEW15! Buy now`.
+
+    ![before-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/before-alert-icon___86e395e9cfc731f1f70b56cf3760af08.png)
+
+- **After**
+  
+    The native Alert was replaced with the custom one, which brings a new icon, the `Star`, from the `@faststore/ui` iconography library, following the sentence `Rate your favorite item`.
+
+    ![after-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/after-custom-alert-icon___87cd248c0c406640aaaac4ef9238e101.png)

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -37,7 +37,7 @@ By leveraging `getOverriddenSection`, you can customize the Alert section's Head
 
 4. Define the `CustomIconsAlert` component:
 
-        ```tsx focus=3:5
+        ```tsx focus=3:7
         import { AlertSection, getOverriddenSection } from '@faststore/core'
 
         const CustomIconsAlert = getOverriddenSection({

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -19,7 +19,7 @@ This guide illustrates a common use case for [`getOverriddenSection`](https://de
     | `Truck`                 | ![truck-icon](https://vtexhelp.vtexassets.com/assets/docs/src/truck-icon___ec3a7f0fcf2c02580d49444b71e8fc36.png)   |
     | `User`                  | ![user-icon](https://vtexhelp.vtexassets.com/assets/docs/src/user-icon___999dffa96120d0e51ead18263423ddad.png) |
 
-- You want to allow Headless CMS editors to select in the Alert section from a wider range of icons supported by the `@faststore/ui` [iconography library](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage).
+- You want to allow Headless CMS editors to select in the Alert section from a wider range of icons supported by the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library.
 
 ## Implementation
 
@@ -37,7 +37,7 @@ By leveraging `getOverriddenSection`, you can customize the Alert section's Head
 
 4. Define the `CustomIconsAlert` component:
 
-        ```tsx
+        ```tsx focus=3:5
         import { AlertSection, getOverriddenSection } from '@faststore/core'
 
         const CustomIconsAlert = getOverriddenSection({
@@ -52,11 +52,11 @@ By leveraging `getOverriddenSection`, you can customize the Alert section's Head
     - The override options specify:
       - **`Section`:** The section to be overridden (Alert).
 
-    > ℹ️ For further details on code implementation, see the `CustomIconsAlert` folder available in the playground.store repository.
+    > ℹ️ For further details on code implementation, see the [`CustomIconsAlert`](https://github.com/vtex-sites/playground.store/tree/main/src/components/sections/CustomIconsAlert) folder available in the [playground.store](https://github.com/vtex-sites/playground.store) repository.
 
 ### Synchronizing the changes with the Headless CMS
 
-Add the section to the Headless CMS by following the instructions available in [Sending components to the Headless CMS](https://developers.vtex.com/docs/guides/building-sections/overrides/sending-components-to-the-headless-cms). The following schema was used as an example:
+Add the section to the Headless CMS by following the instructions available in [syncing components to the Headless CMS](https://developers.vtex.com/docs/guides/faststore/overrides-syncing-components-with-the-headless-cms). The following schema was used as an example:
 
         ```json
         {
@@ -104,20 +104,20 @@ Add the section to the Headless CMS by following the instructions available in [
         }
         ```
 
-> ℹ️ For further details on code implementation, see the `sections.json` file available in the playground.store repository.
+> ℹ️ For further details on code implementation, see the [`sections.json`](https://github.com/vtex-sites/playground.store/blob/main/cms/faststore/sections.json#L1-L55) file available in the [playground.store](https://github.com/vtex-sites/playground.store) repository.
 
 ## Results
 
-Once you have [set your development mode](https://developers.vtex.com/docs/guides/building-sections/overrides/sending-components-to-the-headless-cms#previewing-changes-in-the-development-mode) to see the changes locally, you can see the new Alert icon. Below, you can check an example storefront before and after the instructions in this guide:
+Once you have [set your development mode](https://developers.vtex.com/docs/guides/faststore/headless-cms-previewing-changes-in-development-mode) to see the changes locally, you can see the new Alert icon. Below, you can check an example storefront before and after the instructions in this guide:
 
 - **Before**
 
-    The native Alert displays one of the default icons, the `BellRinging`, following the sentence `Get 15% off today: NEW15! Buy now`.
+    The native Alert displays one of the default icons, `BellRinging`, alongside the text `Get 15% off today: NEW15! Buy now`.
 
     ![before-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/before-alert-icon___86e395e9cfc731f1f70b56cf3760af08.png)
 
 - **After**
   
-    The native Alert was replaced with the custom one, which brings a new icon, the `Star`, from the `@faststore/ui` iconography library, following the sentence `Rate your favorite item`.
+    The native Alert was replaced with the custom one, which brings a new icon, `Star`, from the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library, alongside the text `Rate your favorite item`.
 
     ![after-custom-icon](https://vtexhelp.vtexassets.com/assets/docs/src/after-custom-alert-icon___87cd248c0c406640aaaac4ef9238e101.png)

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/adding-more-icon-options-to-the-alert-component.mdx
@@ -27,15 +27,15 @@ This guide illustrates a common use case for [`getOverriddenSection`](https://de
 
 By leveraging `getOverriddenSection`, you can customize the Alert section's Headless CMS schema to offer additional icon options. Follow the steps below:
 
-1.  In the `src/components/sections` folder, create the folder `CustomIconsAlert` folder.
-2.  In the `CustomIconsAlert` folder, create the `CustomIconsAlert.tsx` file.
-3.  Import the following to the `CustomIconsAlert.tsx` file:
+1. In the `src/components/sections` folder, create the folder `CustomIconsAlert` folder.
+2. In the `CustomIconsAlert` folder, create the `CustomIconsAlert.tsx` file.
+3. Import the following to the `CustomIconsAlert.tsx` file:
 
         ```tsx
         import { getOverriddenSection } from '@faststore/core'
         ```
 
-4.  Define the `CustomIconsAlert` component:
+4. Define the `CustomIconsAlert` component:
 
         ```tsx focus=3:7
         import { AlertSection, getOverriddenSection } from '@faststore/core'

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/overview.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/overview.mdx
@@ -2,11 +2,11 @@
 title: 'Section override use cases'
 ---
 
-The Section override use cases provide an introduction, instructions for implementation, and results in the storefront, showing how we can implement section overrides. These examples can help you understand and leverage this feature.
+The Section override use cases provide an introduction, instructions for implementation, and results in the storefront, showing how we can implement [section override](https://developers.vtex.com/docs/guides/faststore/overrides-overview). These examples can help you understand and leverage this feature.
 
 | Use case | Description |
 | -------- | ----------- |
-| [Adding more icons options to the Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-more-icon-options-to-the-alert-component) | Create a dropdown in the Headless CMS, allowing editors to choose from a wider selection of icons supported by the `@faststore/ui` library.    |
+| [Adding more icons options to the Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-more-icon-options-to-the-alert-component) | Add more icons options to the Alert, allowing editors to choose from a wider selection of icons supported by the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library.|
 | [Adding an image to your Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-an-image-to-the-alert-component) | Make alert messages more engaging by allowing images alongside text content. |
 
 > ℹ️ In each use case guide, you can get more code details by accessing the [playground.store](https://github.com/vtex-sites/playground.store) repository, which provides more in-depth details of the examples.

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/overview.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/overview.mdx
@@ -1,0 +1,12 @@
+---
+title: 'Section override use cases'
+---
+
+The Section override use cases provide an introduction, instructions for implementation, and results in the storefront, showing how we can implement section overrides. These examples can help you understand and leverage this feature.
+
+| Use case | Description |
+| -------- | ----------- |
+| [Adding more icons options to the Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-more-icon-options-to-the-alert-component) | Create a dropdown in the Headless CMS, allowing editors to choose from a wider selection of icons supported by the `@faststore/ui` library.    |
+| [Adding an image to your Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-an-image-to-the-alert-component) | Make alert messages more engaging by allowing images alongside text content. |
+
+> ℹ️ In each use case guide, you can get more code details by accessing the [playground.store](https://github.com/vtex-sites/playground.store) repository, which provides more in-depth details of the examples.

--- a/docs/faststore/docs/customization/building-sections/override-use-cases/overview.mdx
+++ b/docs/faststore/docs/customization/building-sections/override-use-cases/overview.mdx
@@ -9,4 +9,4 @@ The Section override use cases provide an introduction, instructions for impleme
 | [Adding more icons options to the Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-more-icon-options-to-the-alert-component) | Add more icons options to the Alert, allowing editors to choose from a wider selection of icons supported by the `@faststore/ui` [iconography](https://developers.vtex.com/docs/guides/faststore/reference-icons#usage) library.|
 | [Adding an image to your Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-an-image-to-the-alert-component) | Make alert messages more engaging by allowing images alongside text content. |
 
-> ℹ️ In each use case guide, you can get more code details by accessing the [playground.store](https://github.com/vtex-sites/playground.store) repository, which provides more in-depth details of the examples.
+> ℹ️ You can find the code for each use case in the [playground.store](https://github.com/vtex-sites/playground.store) repository, which provides more in-depth details of the examples.

--- a/docs/faststore/docs/customization/dynamic-content/overview.mdx
+++ b/docs/faststore/docs/customization/dynamic-content/overview.mdx
@@ -6,7 +6,7 @@ Dynamic Content allows you to customize your home and landing pages with server-
 
 ![dynamic-content-headless-cms](https://vtexhelp.vtexassets.com/assets/docs/src/dynamic-content-feature___31dbd2fb1003d00bf492eb6479e3fe0c.gif)
 
-*This video guides you on creating a landing page in the Headless CMS and using Dynamic Content on it. In this example, we've already set up the dynamic content in the store code, including the page slug, `/my-landing-page`. The landing page features two Hero sections: a [native one](https://developers.vtex.com/docs/guides/faststore/organisms-hero) displaying an image added from the Headless CMS, and a custom one with a fixed image sourced directly from an API defined in the store code.*
+*In the example above, we've already set up the page slug, `/my-landing-page`, in the store code, and now we are including it in the Headless CMS. The landing page features two Hero sections: a [native one](https://developers.vtex.com/docs/guides/faststore/organisms-hero) displaying an image added from the Headless CMS, and a custom one with a fixed image sourced directly from an API defined in the store code.*
 
 > ℹ️ For other types of pages, such as collections (PLPs) and product pages (PDPs), server-side data fetching is already available via API Extensions. Refer to the [API Extension documentation](https://developers.vtex.com/docs/guides/faststore/api-extensions-overview) for more details on fetching data for these pages.
 
@@ -16,19 +16,19 @@ Dynamic Content allows you to customize your home and landing pages with server-
 
 ### Update the `@faststore/core` package
 
-To benefit from this feature,  your store `@faststore/core` package must have a version equal to or above  `v3.0.0`. Follow the steps below to update the package:
+To benefit from this feature,  your store `@faststore/core` package must have a version equal to or above  `v3.0.55`. Follow the steps below to update the package:
 
-1. Update your store’s `@faststore/core` package to, for example, the `v3.0.0` by running the following command:
+1. Update your store’s `@faststore/core` package to, for example, the `v3.0.55` by running the following command:
 
     ```bash
-    yarn add @faststore/core@3.0.0
+    yarn add @faststore/core@3.0.55
     ```
 
 2. Run `yarn dev` to sync the changes to your project.
 
-### Understand Section Override and API extensions
+### Understand Section Override
 
-To work with dynamic content, you need knowledge of [Section Override](https://developers.vtex.com/docs/guides/faststore/overrides-overview) and [API extensions](https://developers.vtex.com/docs/guides/faststore/api-extensions-overview).
+To work with dynamic content, you need knowledge of [Section Override](https://developers.vtex.com/docs/guides/faststore/overrides-overview).
 
 </Steps>
 
@@ -37,4 +37,4 @@ To work with dynamic content, you need knowledge of [Section Override](https://d
 To use the Dynamic Content feature in your home and landing pages, refer to the following guides:
 
 - [Setting up your store code for Dynamic Content](https://developers.vtex.com/docs/guides/faststore/dynamic-content-setting-up-the-store-code-for-dynamic-content): Request Fetch API or any HTTP library to fetch the data directly ([Axios](https://axios-http.com/docs/intro), fetch, etc). 
-- [Consuming Dynamic Content within custom sections](https://developers.vtex.com/docs/guides/faststore/dynamic-content-consuming-the-dynamic-content-in-custom-sections): Fetch the data using the existing API Extension feature.
+- [Consuming Dynamic Content within sections](https://developers.vtex.com/docs/guides/faststore/dynamic-content-consuming-the-dynamic-content-in-custom-sections): Fetch the data using the existing API Extension feature.


### PR DESCRIPTION
#### Types of changes
- [x] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Checking the preview

1. Open [this URL](https://developers.vtex.com/api/preview?branch=EDU-12592-override-use-cases) to set up the portal with this branch changes.
2. Access the following guides:
    -  [Overview](https://developers.vtex.com/docs/guides/faststore/override-use-cases-overview)
    - [Adding more icon options to the Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-more-icon-options-to-the-alert-component)
    - [Adding an image to the Alert component](https://developers.vtex.com/docs/guides/faststore/override-use-cases-adding-an-image-to-the-alert-component)
