### PR TITLE
Docs: Add taxes label design tokens

### DIFF
--- a/docs/faststore/components/molecules/order-summary.mdx
+++ b/docs/faststore/components/molecules/order-summary.mdx
@@ -91,6 +91,20 @@ Follow the instructions in the [Importing FastStore UI component styles](https:/
     token="--fs-order-summary-total-text-font-weight"
     value="var(--fs-text-weight-bold)"
   />
+  <TokenDivider />
+  <TokenRow
+    token="--fs-order-summary-taxes-label-color"
+    value="var(--fs-color-info-text)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-size"
+    value="var(--fs-text-size-tiny)"
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-weight"
+    value="var(--fs-text-weight-regular)"
+  />
 </TokenTable>
 
 ---
@@ -116,3 +130,5 @@ Follow the instructions in the [Importing FastStore UI component styles](https:/
 `data-fs-order-summary-total-label`
 
 `data-fs-order-summary-total-value`
+
+`data-fs-order-summary-taxes-label`

--- a/docs/faststore/components/molecules/product-card.mdx
+++ b/docs/faststore/components/molecules/product-card.mdx
@@ -366,6 +366,24 @@ All product card related components support all attributes also supported by the
   />
 </TokenTable>
 
+#### Tax Label
+
+<TokenTable>
+  <TokenRow
+    token="--fs-order-summary-taxes-label-color"
+    value="var(--fs-color-info-text)"
+    isColor
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-size"
+    value="var(--fs-text-size-tiny)"
+  />
+  <TokenRow
+    token="--fs-order-summary-taxes-text-weight"
+    value="var(--fs-text-weight-regular)"
+  />
+</TokenTable>
+
 ### Variants
 
 #### Default
@@ -693,6 +711,8 @@ Use the `ProductCard` to:
 `data-fs-product-card-prices`
 
 `data-fs-product-card-actions`
+
+`data-fs-product-card-taxes-label`
 
 ---
 


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [X] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

## What's the purpose of this pull request?

Add Price With Taxes documentation

## How it works?

This PR adds news token and Props comming from Price wIth Taxes feature.

## How to test it?

Access the Doc Portal
[Order Summary](https://faststore-site-git-docs-add-price-wit-taxes-docs-faststore.vercel.app/components/molecules/order-summary)

### Props

![Screenshot 2024-07-15 at 10 47 14](https://github.com/user-attachments/assets/1c94d106-3027-43b2-b275-b99175b3134d)

### Tokens

![Screenshot 2024-07-15 at 10 47 23](https://github.com/user-attachments/assets/c5a6ce0a-664e-43a0-9430-ffaff2b388d9)


[Product Card](https://faststore-site-git-docs-add-price-wit-taxes-docs-faststore.vercel.app/components/molecules/product-card#design-tokens)

### Tokens

![Screenshot 2024-07-15 at 10 46 57](https://github.com/user-attachments/assets/6e7b113b-6c45-4ff3-aa90-71aa7de9d5f3)

### Props

![Screenshot 2024-07-15 at 10 46 42](https://github.com/user-attachments/assets/b0381e69-bf22-4dfb-8713-eaf3a4774c8d)


### Starters Deploy Preview

https://vercel.live/open-feedback/faststore-site-git-docs-add-price-wit-taxes-docs-faststore.vercel.app?via=pr-comment-visit-preview-link&passThrough=1



