### PR TITLE
Fix: FastStore API Schema tag errors

### DIFF
--- a/docs/faststore/docs/faststore-api/schema/mutations.mdx
+++ b/docs/faststore/docs/faststore-api/schema/mutations.mdx
@@ -57,7 +57,6 @@ Web session identifier.
 </thead>
 <tbody>
 <tr>
-<tr>
 <td colspan="2" valign="top"><strong>validateSession</strong></td>
 <td valign="top"><a href="https://developers.vtex.com/docs/guides/faststore/schema-objects#storesession">StoreSession</a></td>
 <td>

--- a/docs/faststore/docs/faststore-api/schema/mutations.mdx
+++ b/docs/faststore/docs/faststore-api/schema/mutations.mdx
@@ -41,7 +41,7 @@ Web session identifier.
 
 </td>
 </tr>
-</thead>
+</tbody>
 </table>
 
 ## Session
@@ -55,6 +55,7 @@ Web session identifier.
 <th align="left">Description</th>
 </tr>
 </thead>
+<tbody>
 <tr>
 <tr>
 <td colspan="2" valign="top"><strong>validateSession</strong></td>

--- a/docs/faststore/docs/faststore-api/schema/queries.mdx
+++ b/docs/faststore/docs/faststore-api/schema/queries.mdx
@@ -4,7 +4,7 @@ title: "Queries"
 
 Arguments must be provided by the user.
 
-Arguments preeceded by an exclamation mark (`!`) are not nullable.
+Arguments preceded by an exclamation mark (`!`) are not nullable.
 
 ## Product
 
@@ -62,7 +62,7 @@ Product pagination argument, indicating the cursor corresponding with the item a
 
 </td>
 </tr>
-</thead>
+</tbody>
 </table>
 
 ## Collection


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

There are some tag errors in the FastStore API Schema documentation. This PR aims to fix and solve some issues during the Dev Portal build.