### PR TITLE
Update checking-your-stores-binding-id.md

### DIFF
--- a/docs/guides/vtex-io/Storefront-Guides/vtex-io-cross-border-stores/checking-your-stores-binding-id.md
+++ b/docs/guides/vtex-io/Storefront-Guides/vtex-io-cross-border-stores/checking-your-stores-binding-id.md
@@ -14,7 +14,7 @@ Hence, for a step by step on how to access this information, check the following
 
 1. [Install](https://developers.vtex.com/docs/guides/vtex-io-documentation-installing-an-app) the `vtex.admin-graphql-ide@3.x` app using your terminal.
 2. Access the **GraphQL admin IDE**.
-3. From the dropdown list, choose the `vtex.tenant` app.
+3. From the dropdown list, choose the `vtex.tenant-graphql@0.x.x` app.
 4. Write the following query command in the text box that is displayed:
 
 ```gql


### PR DESCRIPTION
Changed the name "vtex.tenant" to "vtex.tenant-graphql@0.x.x" to indicate the correct app to consult the binding information.

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ x ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
