### PR TITLE
Update vtex-io-documentation-5-writingtheheaderandbodyscripts.md

### DIFF
--- a/docs/guides/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-5-writingtheheaderandbodyscripts.md
+++ b/docs/guides/vtex-io/Getting-Started/vtex-io-documentation-1-developnativeintegrationswithpixelapps/vtex-io-documentation-5-writingtheheaderandbodyscripts.md
@@ -15,7 +15,7 @@ Adding a script to the `<header>` ensures that it will be executed before any ot
 
 ## Instructions
 
-1. Open the `pixel/header.html` file and replace the provided function with your own.
+1. Open the `pixel/head.html` file and replace the provided function with your own.
 
   > ℹ️ If you choose to execute your script inside the `<body>` tag, rename the `header.html` file to `body.html`.
 


### PR DESCRIPTION
File in "pixel/" must be called "head.html" and not "header".

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
