### PR TITLE
EDU-13703: WebOps installation requirements

### DIFF
--- a/docs/faststore/docs/getting-started/1-onboarding/overview.mdx
+++ b/docs/faststore/docs/getting-started/1-onboarding/overview.mdx
@@ -8,10 +8,9 @@ This document provides an overview of the FastStore WebOps app, a tool designed 
 
 <Steps>
 
-### Request the app's installation
+### Install the app
 
-Please open a ticket with the [VTEX support team](https://help.vtex.com/support) to request the installation of the FastStore WebOps app.
-
+Make sure you installed the app to your store account by following the instructions in [Install the FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-the-fastStore-webops-app).
 
 ### Create your store Catalog
 

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -95,8 +95,32 @@ If you are using a different major version and want to migrate, please [open a t
 
 </details>
 
-## Request the installation of the FastStore WebOps app
+## Install the FastStore WebOps app
 
-[Open a ticket with the VTEX support team](https://help.vtex.com/support) and request the installation of the [FastStore WebOps](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) app.
+To be able to start your FastStore project, make sure to install the [FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) in your account.
+The app is your first step on creating and setting up setting up a store and gives you a clear view of your website's deployments and performance.
+
+To install the WebOps app, follow these steps:
+
+1. In a terminal, log into your VTEX account by running the following:
+
+    ```bash
+    vtex login {accountName}
+    ```
+
+    > ⚠️ Remember to change the `{accountName}` for your account name, for example `vtex login store`.
+
+2. Install the FastStore WebOps app by running the following command:
+
+    ```bash
+    vtex install vtex.webops
+    ```
+3. The following message will appear and type `y`.
+
+    ```bash
+    ? Are you sure you want to force this operation on the master workspace on the account store? » (y/N)
+    ```
+After typing `y` the following successful message will appear and the app is already installed in your account. 
+Now, you can start using the app by following the [FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) guide.
 
 </Steps>

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -97,10 +97,9 @@ If you are using a different major version and want to migrate, please [open a t
 
 ## Install the FastStore WebOps app
 
-To be able to start your FastStore project, make sure to install the [FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) in your account.
-The app is your first step on creating and setting up setting up a store and gives you a clear view of your website's deployments and performance.
+The [FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) is the first step for you to create and set up a FastStore project. It also provides you a clear view of your website's deployments and performance.
 
-To install the WebOps app, follow these steps:
+To install the app, follow these steps:
 
 1. In a terminal, log into your VTEX account by running the following:
 
@@ -108,19 +107,19 @@ To install the WebOps app, follow these steps:
     vtex login {accountName}
     ```
 
-    > ⚠️ Remember to change the `{accountName}` for your account name, for example `vtex login store`.
+    > ⚠️ Replace `{accountName}` with your store account name, for example `vtex login store`.
 
 2. Install the FastStore WebOps app by running the following command:
 
     ```bash
     vtex install vtex.webops
     ```
-3. The following message will appear and type `y`.
+
+3. A confirmation message will appear. Type `y` to proceed.
 
     ```bash
     ? Are you sure you want to force this operation on the master workspace on the account store? » (y/N)
     ```
-After typing `y` the following successful message will appear and the app is already installed in your account. 
-Now, you can start using the app by following the [FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) guide.
+The FastStore WebOps app is now installed in your account. Refer to the [FastStore WebOps app](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview) guide to create your first FastStore project.
 
 </Steps>


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

In this phase of the FastStore product, users can now install the WebOps app 
 by themselves and do not need to open a ticket for support to install it anymore. This PR reviews the doc to instruct how users can install the WebOps app in their VTEX account.