### PR TITLE
EDU-13702: Fix 'Overriding native component's props'

### DIFF
--- a/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
@@ -80,7 +80,11 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
     ```tsx index.tsx
     import ProductDetailsWithCustomButton from "./sections/ProductDetailsWithCustomButton";
 
-    export default { ProductDetailsWithCustomButton };
+    const sections = {
+
+    ProductDetails: ProductDetailsWithCustomButton
+    };
+    export default sections;
 
     ```
 

--- a/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
@@ -20,7 +20,8 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
 ### Step 1 - Setting up the component file
 
 1. After choosing a native section to be customized from the [list of available native sections](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections), open your FastStore project in any code editor of your preference.
-2. Go to the `src` folder, create the `components` folder, and inside it, create the `sections` folder. You can run the following command to create them:
+2. Create a new branch to work with the custom component you will create.
+3. Go to the `src` folder, create the `components` folder, and inside it, create the `sections` folder. You can run the following command to create them:
 
     > ℹ️ The naming of the `sections` folder is arbitrary, as overrides can be created in any file since the import is made in the `src/components/index.tsx` file. 
 
@@ -29,7 +30,7 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
         <Tab>```bash copy mkdir src\components src\components\sections ```</Tab>
     </Tabs>
 
-3. In the `sections` folder, create a new file for your customized section. For example, create a new file named `ProductDetailsWithCustomButton.tsx` under the `src/components/sections` directory.
+4. In the `sections` folder, create a new file for your customized section. For example, create a new file named `ProductDetailsWithCustomButton.tsx` under the `src/components/sections` directory.
 
     <Tabs items={['macOS and Linux', 'Windows']}>
         <Tab>
@@ -41,7 +42,7 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
         </Tab>
     </Tabs>
 
-4. Copy and paste the following code snippet into the file:
+5. Copy and paste the following code snippet into the file:
 
     ```tsx ProductDetailsWithCustomButton.tsx
     import { ProductDetailsSection, getOverriddenSection } from '@faststore/core'
@@ -56,7 +57,7 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
 
     > ℹ️ Change the value of the `Section` variable to the section you wish to override. In the given example, we set the `Section` variable to the component `ProductDetailsSection` to override this specific section.
 
-5. Save your changes.
+6. Save your changes.
 
 ### Step 2 - Setting up the override
 
@@ -75,7 +76,7 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
     export default ProductDetailsWithCustomButton;
     ```
 
-2. In the `components` folder, create the `index.tsx` file and add the following:
+2. In the `components` folder, create the `index.tsx` file and add the following. This code overrides the `BuyButton` props `size` and `iconPosition`.
 
     ```tsx index.tsx
     import ProductDetailsWithCustomButton from "./sections/ProductDetailsWithCustomButton";
@@ -88,183 +89,13 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
 
     ```
 
-This code overrides the `BuyButton` props `size` and `iconPosition`. You'll see a smaller button than the initial one, and the cart icon positioned on the right side.
+3. Run `yarn dev` to sync the new custom component to your store preview. You'll see a smaller button than the initial one, and the cart icon positioned on the right side.
 
-### Step 3 - Adding the component to the CMS
+### Step 3 - Publishing your changes
 
-To integrate the section into the [Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview), follow the steps below:
+If your changes are working locally and you want to publish them in production, follow the steps below:
 
-1. Create a folder named `cms` in the FastStore root directory.
-2. Inside `cms`, create the `faststore` folder.
-3. Within the `cms/faststore` folder, create the `sections.json` file.
-4. Add the schema of the new section to the `sections.json` file, named `ProductDetailsWithCustomButton`, to the `sections.json` file:
-
-    ```json sections.json
-    [
-    {
-        "name": "ProductDetailsWithCustomButton",
-        "requiredScopes": ["pdp"],
-        "schema": {
-        "title": "Product Details WithCustom Button",
-        "type": "object",
-        "description": "Display Product Details Section with custom button",
-        "properties": {
-            "productTitle": {
-            "title": "Product Title",
-            "type": "object",
-            "properties": {
-                "discountBadge": {
-                "title": "Discount Badge",
-                "type": "object",
-                "properties": {
-                    "showDiscountBadge": {
-                    "title": "Show Discount Badge?",
-                    "type": "boolean",
-                    "default": false
-                    },
-                    "size": {
-                    "title": "Size",
-                    "type": "string",
-                    "enumNames": ["Big", "Small"],
-                    "enum": ["big", "small"]
-                    }
-                }
-                },
-                "refNumber": {
-                "title": "Show Reference Number?",
-                "type": "boolean",
-                "default": false
-                }
-            }
-            },
-            "buyButton": {
-            "title": "Buy Button",
-            "type": "object",
-            "properties": {
-                "title": {
-                "title": "Title",
-                "type": "string",
-                "default": "Add to Cart"
-                },
-                "icon": {
-                "title": "Icon",
-                "type": "object",
-                "properties": {
-                    "icon": {
-                    "title": "Icon",
-                    "type": "string",
-                    "enumNames": ["Shopping Cart"],
-                    "enum": ["ShoppingCart"]
-                    },
-                    "alt": {
-                    "type": "string",
-                    "title": "Alternative Label",
-                    "default": "Shopping Cart"
-                    }
-                }
-                }
-            }
-            },
-            "notAvailableButton": {
-            "title": "Not Available Button",
-            "description": "Shown when a SKU is not available",
-            "type": "object",
-            "properties": {
-                "title": {
-                "title": "Title",
-                "type": "string",
-                "default": "Not Available"
-                }
-            }
-            },
-            "shippingSimulator": {
-            "title": "Shipping Simulation",
-            "type": "object",
-            "properties": {
-                "title": {
-                "title": "Title",
-                "type": "string",
-                "default": "Shipping"
-                },
-                "inputLabel": {
-                "title": "Input Label",
-                "type": "string",
-                "default": "Postal Code"
-                },
-                "link": {
-                "title": "Postal Code Discovery",
-                "type": "object",
-                "properties": {
-                    "text": {
-                    "title": "Link Text",
-                    "type": "string",
-                    "default": "I don't know my Postal Code"
-                    },
-                    "to": { "title": "URL", "type": "string" }
-                }
-                },
-                "shippingOptionsTableTitle": {
-                "title": "Shipping Options Table Header",
-                "type": "string"
-                }
-            }
-            },
-            "productDescription": {
-            "title": "Product Description",
-            "type": "object",
-            "properties": {
-                "initiallyExpanded": {
-                "type": "string",
-                "title": "Initially Expanded?",
-                "enumNames": ["First", "All", "None"],
-                "enum": ["first", "all", "none"]
-                },
-                "displayDescription": {
-                "title": "Should display description?",
-                "type": "boolean",
-                "default": true
-                },
-                "title": {
-                "title": "Description section title",
-                "type": "string",
-                "default": "Description"
-                }
-            }
-            }
-        }
-        }
-    }
-    ]
-    ```
-
-This schema Adds the new `Product Details with custom button` section to the Headless CMS.
-
-5. Open a new terminal window and log in to your vtex account by running `vtex login {accountName}`.
-6. run the following command to sync your changes with the Headless CMS:
-
-    ```bash
-    yarn cms-sync
-    ```
-
-7. Access the VTEX Admin and proceed to **Storefront > Headless CMS**.
-8. Click on the page you desire to add the new section.
-9. Click the add button (`+`), add the new section, and complete values from the section fields.
-10. Click `Save`.
-
-    > ⚠️ Remember: props changed via Headless CMS overlap the changes made through [overrides](/tbs). For example, if you change a prop through override and also change it using Headless CMS, the final prop's value will be the one added using CMS.
-
-### Step 4 - Visualizing the component on the page locally
-
-To see your changes locally, you must set the Headless CMS preview to the development mode. For more information, refer to the [Previewing Headless CMS changes in development mode](https://developers.vtex.com/docs/guides/faststore/headless-cms-previewing-changes-in-development-mode) guide.
-
-Once you have set the preview for development mode, you should see your new Buy Button in a Product Details Page (PDP):
-
-    ![overrides-PDP-buy-button-props](https://vtexhelp.vtexassets.com/assets/docs/src/overrides-pdp-buy-button-props___898b016bd82c908b5b24c8822be6789a.png)
-
-### Step 5 - Publishing your changes
-
-If your changes are working in the development mode and you want to publish them, follow the steps below:
-
-1. Go to the Headless CMS in the VTEX Admin.
-2. Click on a PDP page.
-3. Click `Publish` to make the new button available on the production store.
+1. Publish your branch with the custom components files.
+2. Open a pull request in the store's GitHub repository.
+3. Review the pull request
+4. Merge the changes from this branch to the `main` one and the new component will be available in the live store.

--- a/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
@@ -89,7 +89,8 @@ it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/
 
     ```
 
-3. Run `yarn dev` to sync the new custom component to your store preview. You'll see a smaller button than the initial one, and the cart icon positioned on the right side.
+3. Open the terminal, and run `yarn dev` to sync the new custom component to your store preview. 
+4. Open the localhost available after running `yarn dev`. You'll see a smaller button than the initial one, and the cart icon positioned on the right side.
 
 ### Step 3 - Publishing your changes
 

--- a/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
+++ b/docs/faststore/docs/customization/building-sections/overrides/component-props.mdx
@@ -16,6 +16,7 @@ Make sure your `@faststore/core` package has the 3.x version or above. If you ne
 it, refer to this [release note](https://github.com/vtex/faststore/releases/tag/v3.0.0).
 
 ## Instructions
+
 ### Step 1 - Setting up the component file
 
 1. After choosing a native section to be customized from the [list of available native sections](https://developers.vtex.com/docs/guides/faststore/building-sections-list-of-native-sections), open your FastStore project in any code editor of your preference.


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Revisando a trilha de Section override, foi notado alguns erros e melhorias que precisam ser feitos devido as últimas atualizações da FastStore. Esse PR corrigi e atualiza a documentação abaixo:

Doc: [Overriding native component's props](https://developers.vtex.com/docs/guides/faststore/overrides-component-props)

- Corrigir code snippte de `index.tsx` em 'Step 2 - Setting up the override'..
- Rodar `yarn dev` : Após o 'Step 2', adicionar o passo de rodar `yarn dev` para ver o novo component funcionando no localhost.
- Os 'Step 3' e 'Step 4' não são necessários, aqui estamos fazendo o override de prop para eventualmente aparecer na loja em production e não substituindo uma componente por outro no Headless CMS.
- Corrigir 'Step 5' para publicar o novo componente para loja em produção.