### PR TITLE
fix code block on md store form guide

### DIFF
--- a/docs/guides/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-creating-a-native-form-for-your-store-users.md
+++ b/docs/guides/vtex-io/Storefront-Guides/concepts-1/vtex-io-documentation-creating-a-native-form-for-your-store-users.md
@@ -21,7 +21,7 @@ Make a request to the [Save Schema by name](https://developers.vtex.com/docs/api
 
 <details>
   <summary>Schema example</summary>
-  <pre>
+  ```json
   {
     "title": "Person",
     "type": "object",
@@ -100,7 +100,7 @@ Make a request to the [Save Schema by name](https://developers.vtex.com/docs/api
       "publicFilter": [ "fieldExample" ]
     }
   }
-  </pre>
+  ```
 </details>
 
 > ℹ️ Bear in mind that the schema's language will define the form's default language.


### PR DESCRIPTION
before:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/cc59af13-4688-4e82-a75b-04e732274e74">

after:
<img width="512" alt="image" src="https://github.com/user-attachments/assets/97c262a1-0e76-4244-be16-894b17e28790">


#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)
