### PR TITLE
EDU-13838: Feedback for Installing FastStore CLI doc

### DIFF
--- a/docs/faststore/docs/getting-started/3-faststore-cli.mdx
+++ b/docs/faststore/docs/getting-started/3-faststore-cli.mdx
@@ -6,7 +6,7 @@ The FastStore Command Line Interface (CLI) provides pre-configured scripts for s
 
 ## Before you begin
 
-To avoid errors while running the FastStore CLI `yarn faststore cms-sync` or `faststore cms-sync` commands, make sure to install the Headless CMS, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements).
+To ensure the FastStore CLI commands related to the Headless CMS run correctly, make sure to install the Headless CMS, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements).
 
 ## Running FastStore CLI on the project
 

--- a/docs/faststore/docs/getting-started/3-faststore-cli.mdx
+++ b/docs/faststore/docs/getting-started/3-faststore-cli.mdx
@@ -6,7 +6,7 @@ The FastStore Command Line Interface (CLI) provides pre-configured scripts for s
 
 ## Before you begin
 
-To avoid errors while running the FastStore CLI `yarn faststore cms-sync` or `faststore cms-sync` commands, make sure to install the Headless CMS, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#2-ensure-the-headless-cms-and-its-ependencies-are-installed-in-your-account).
+To avoid errors while running the FastStore CLI `yarn faststore cms-sync` or `faststore cms-sync` commands, make sure to install the Headless CMS, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements).
 
 ## Running FastStore CLI on the project
 

--- a/docs/faststore/docs/getting-started/3-faststore-cli.mdx
+++ b/docs/faststore/docs/getting-started/3-faststore-cli.mdx
@@ -4,6 +4,10 @@ title: '3. FastStore CLI'
 
 The FastStore Command Line Interface (CLI) provides pre-configured scripts for starting, building, and developing FastStore projects. It also helps keep FastStore projects up to date with the [`@faststore/core`](https://developers.vtex.com/docs/guides/faststore/project-structure-overview#packagejson) package.
 
+## Before you begin
+
+To avoid errors while running the FastStore CLI `yarn faststore cms-sync` or `faststore cms-sync` commands, make sure to install the Headless CMS, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#2-ensure-the-headless-cms-and-its-ependencies-are-installed-in-your-account).
+
 ## Running FastStore CLI on the project
 
 The CLI is automatically added as a dependency in your project's `package.json` file, so once you run `yarn install` during the [project setup](https://developers.vtex.com/docs/guides/faststore/getting-started-2-setting-up-the-project), you can start using it in the project.

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -47,7 +47,7 @@ If yes, proceed to check the [next requirement](https://developers.vtex.com/docs
     vtex install vtex.admin-cms-graphql vtex.admin-cms-graphql-rc
     ```
 
-Once the app and its dependencies are installed, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins). If not, install them by following the instructions in [Installing the Headless CMS app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
+Once the app and its dependencies are installed, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins).
 
 ## Install Headless CMS plugins
 

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -9,10 +9,10 @@ updatedAt: "2024-06-03T11:30:00.813Z"
 
 For more information, please refer to [this guide](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
 
-## Install the Headless CMS and its dependencies
+## Install Headless CMS and its dependencies
 
-The [Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview) is the content management solution for FastStore projects. During the [Onboarding](https://developers.vtex.com/docs/guides/faststore/getting-started-overview),
-the integration between your project and the Headless CMS is initiated.
+[Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview) is the content management solution for FastStore projects. During the [Onboarding](https://developers.vtex.com/docs/guides/faststore/getting-started-overview),
+the integration between your project and Headless CMS is initiated.
 
 To prevent content duplication that could cause build failures during Onboarding, it is important to confirm the installation of the following apps in your account: 
 - `vtex.admin-cms@1.x`
@@ -41,7 +41,7 @@ If yes, proceed to check the [next requirement](https://developers.vtex.com/docs
 
     ![installation-message](https://vtexhelp.vtexassets.com/assets/docs/src/cms-install___7144afabf5a895ba92905926808507b2.png)
 
-5. Install the Headless CMS dependencies by running the following command:
+5. Install Headless CMS dependencies by running the following command:
 
     ```bash
     vtex install vtex.admin-cms-graphql vtex.admin-cms-graphql-rc
@@ -51,7 +51,7 @@ Once the app and its dependencies are installed, proceed to check the [next requ
 
 ## Install Headless CMS plugins
 
-To ensure you won't get errors while running Headless CMS commands in the CLI, install the Headless CMS plugins by following these steps:
+To ensure you won't get errors while running Headless CMS commands in the CLI, install Headless CMS plugins by following these steps:
 
 1. Open the terminal and log in to your VTEX account using the VTEX IO CLI:
 
@@ -61,13 +61,13 @@ To ensure you won't get errors while running Headless CMS commands in the CLI, i
     vtex login {account}
     ```
 
-2. Install the Headless CMS plugin:
+2. Install Headless CMS plugins:
 
     ```bash
     vtex plugins install cms
     ```
 
-Now, check if the installation of the Headless CMS plugin was successful by running `vtex cms`.
+Now, check if the installation of Headless CMS plugins was successful by running `vtex cms`.
 
 ![success-vtex-cms-sync](https://vtexhelp.vtexassets.com/assets/docs/src/faststore-vtex-cms___460365970fb39c94e300b9fbd497e17e.png)
 

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -9,7 +9,7 @@ updatedAt: "2024-06-03T11:30:00.813Z"
 
 For more information, please refer to [this guide](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
 
-## Install the Headless CMS and dependencies
+## Install the Headless and its dependencies
 
 The [Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview) is the content management solution for FastStore projects. During the [Onboarding](https://developers.vtex.com/docs/guides/faststore/getting-started-overview),
 the integration between your project and the Headless CMS is initiated.
@@ -19,9 +19,7 @@ To prevent content duplication that could cause build failures during Onboarding
 - `vtex.admin-cms-graphql`
 - `vtex.admin-cms-graphql-rc`
 
-To check whether you have them installed, refer to [Installing the Headless CMS app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
-
-### Checking installed apps in your account
+To check whether you have them installed, follow the instructions below:
 
 1. Open the terminal and log in to your account using the following command. *Remember to replace `{accountName}` with your account's name.*
 
@@ -31,12 +29,9 @@ To check whether you have them installed, refer to [Installing the Headless CMS 
 
 2. Run `vtex ls` to list all the installed apps in your account.
 3. Check if the `vtex.admin-cms@1.x`, `vtex.admin-cms-graphql`, and `vtex.admin-cms-graphql-rc` are in the list.
+If yes, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins). If not, install them by following the instructions in [Installing the Headless CMS app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
 
-If yes, proceed to check other requirements. If not, install them by following the instructions in [Installing the Headless CMS app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
-
-### Installing the Headless CMS app and its dependencies
-
-1. After logging into your account, install `vtex.admin-cms@1.x` by running the following command:
+4. After logging into your account, install `vtex.admin-cms@1.x` by running the following command:
 
     ```bash
     vtex install vtex.admin-cms@1.x
@@ -46,13 +41,43 @@ If yes, proceed to check other requirements. If not, install them by following t
 
     ![installation-message](https://vtexhelp.vtexassets.com/assets/docs/src/cms-install___7144afabf5a895ba92905926808507b2.png)
 
-2. Install the Headless CMS dependencies by running the following command:
+5. Install the Headless CMS dependencies by running the following command:
 
     ```bash
     vtex install vtex.admin-cms-graphql vtex.admin-cms-graphql-rc
     ```
 
-Once the app and its dependencies are installed, proceed to check the next requirements.
+Once the app and its dependencies are installed, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins). If not, install them by following the instructions in [Installing the Headless CMS app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
+
+## Install Headless CMS plugins
+
+To ensure you won't get errors while running Headless CMS commands in the CLI, install the Headless CMS plugins by following these steps:
+
+1. Open the terminal and log in to your VTEX account using the VTEX IO CLI:
+
+    > ⚠️ Remember to replace the values between curly brackets according to your account name.
+
+    ```bash
+    vtex login {account}
+    ```
+
+2. Install the Headless CMS plugin:
+
+    ```bash
+    vtex plugins install cms
+    ```
+
+Now, check if the installation of the Headless CMS plugin was successful by running `vtex cms`.
+
+![success-vtex-cms-sync](https://vtexhelp.vtexassets.com/assets/docs/src/faststore-vtex-cms___460365970fb39c94e300b9fbd497e17e.png)
+
+> ⚠️
+>
+> - **Windows user:** If you find problems while installing the plugin, please refer to the [Troubleshooting](https://developers.vtex.com/docs/guides/faststore/troubleshooting-error-installing-headless-cms) article
+>
+> - **macOS user:** If you find problems, run `yarn config set ignore-engines true` to ignore the Node.js incompatibility version, then run `vtex plugins install cms` again.
+>
+> Remember, we recommend using the latest Node.js version or a version higher than `15.0.0`.
 
 ## Enable the VTEX Intelligent Search app in your account
 

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -29,7 +29,7 @@ To check whether you have them installed, follow the instructions below:
 
 2. Run `vtex ls` to list all the installed apps in your account.
 3. Check if the `vtex.admin-cms@1.x`, `vtex.admin-cms-graphql`, and `vtex.admin-cms-graphql-rc` are in the list.
-If yes, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins). If not, install them by following the instructions in [Installing the Headless CMS app](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#installing-the-headless-cms-app-and-its-dependencies).
+If yes, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins). If not, continue following these instructions.
 
 4. After logging into your account, install `vtex.admin-cms@1.x` by running the following command:
 

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -9,7 +9,7 @@ updatedAt: "2024-06-03T11:30:00.813Z"
 
 For more information, please refer to [this guide](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
 
-## Install the Headless and its dependencies
+## Install the Headless CMS and its dependencies
 
 The [Headless CMS](https://developers.vtex.com/docs/guides/faststore/headless-cms-overview) is the content management solution for FastStore projects. During the [Onboarding](https://developers.vtex.com/docs/guides/faststore/getting-started-overview),
 the integration between your project and the Headless CMS is initiated.

--- a/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
+++ b/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
@@ -19,15 +19,15 @@ Before you proceed with setting up the Headless CMS in your account, make sure y
 
 ### Install the Headless CMS, its dependencies and plugins
 
-Ensure that you have installed the `vtex.admin-cms@1.x`, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-and-its-dependencies).
+Make sure that you have installed the `vtex.admin-cms@1.x`, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-and-its-dependencies).
 
-### Successful FastStore Onboarding
+### Have a FastStore project
 
-Make sure the FastStore Onboarding process has been completed successfully through the FastStore WebOps . For detailed instructions, please refer to the [Starting a new FastStore project](https://developers.vtex.com/docs/guides/faststore/getting-started-2-setting-up-the-project) tutorial.
+Make sure you have a FastStore project after completing the process through the FastStore WebOps. For detailed instructions, please refer to the [Starting a new FastStore project](https://developers.vtex.com/docs/guides/faststore/getting-started-2-setting-up-the-project) guide.
 
-### Installation of VTEX IO CLI
+### Install the VTEX IO CLI
 
-Ensure that you have installed the VTEX IO CLI on your machine. This CLI is required to install the Headless CMS plugins and CMS dependencies. For more information, please refer to the [Installing VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-install) guide.
+Make sure that you have installed the VTEX IO CLI on your machine. This CLI is required to install the Headless CMS plugins and CMS dependencies. For more information, please refer to the [Installing VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-install) guide.
 
 </Steps>
 

--- a/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
+++ b/docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx
@@ -13,17 +13,17 @@ The VTEX IO CLI will help you during your development process by allowing you to
 
 ## Before you begin
 
-Before you proceed with setting up the Headless CMS in your account, please ensure the following:
+Before you proceed with setting up the Headless CMS in your account, make sure you:
 
 <Steps>
 
-### Installation of the Headless CMS and its dependencies
+### Install the Headless CMS, its dependencies and plugins
 
-Ensure that you have installed the `vtex.admin-cms@1.x` and its dependencies as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#2-ensure-the-headless-cms-and-its-ependencies-are-installed-in-your-account).
+Ensure that you have installed the `vtex.admin-cms@1.x`, its dependencies and plugins as described in the [FastStore requirements](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-and-its-dependencies).
 
 ### Successful FastStore Onboarding
 
-Make sure the FastStore Onboarding process has been completed successfully. The Headless CMS is installed during this onboarding phase. For detailed instructions, please refer to the [Starting a new FastStore project](https://developers.vtex.com/docs/guides/faststore/getting-started-2-setting-up-the-project) tutorial.
+Make sure the FastStore Onboarding process has been completed successfully through the FastStore WebOps . For detailed instructions, please refer to the [Starting a new FastStore project](https://developers.vtex.com/docs/guides/faststore/getting-started-2-setting-up-the-project) tutorial.
 
 ### Installation of VTEX IO CLI
 
@@ -35,37 +35,9 @@ Ensure that you have installed the VTEX IO CLI on your machine. This CLI is requ
 
 ## Instructions
 
-### Step 1 - Setting up the command-line environment
+### Step 1 - Configuring the Headless CMS
 
-1. Open the terminal and log in to your VTEX account using the VTEX IO CLI:
-
-    > ⚠️ Remember to replace the values between curly brackets according to your account name.
-
-    ```bash
-    vtex login {account}
-    ```
-
-2. Install the Headless CMS plugin:
-
-    ```bash
-    vtex plugins install cms
-    ```
-
-Now, check if the installation of the Headless CMS plugin was successful by running `vtex cms`.
-
-![success-vtex-cms-sync](https://vtexhelp.vtexassets.com/assets/docs/src/faststore-vtex-cms___460365970fb39c94e300b9fbd497e17e.png)
-
-> ⚠️
->
-> - **Windows user:** If you find problems while installing the plugin, please refer to the [Troubleshooting](https://developers.vtex.com/docs/guides/faststore/troubleshooting-error-installing-headless-cms) article
->
-> - **macOS user:** If you find problems, run `yarn config set ignore-engines true` to ignore the Node.js incompatibility version, then run `vtex plugins install cms` again.
->
-> Remember, we recommend using the latest Node.js version or a version higher than `15.0.0`.
-
-### Step 2 - Configuring the Headless CMS
-
-Let's configure the URLs of the webhooks used by the Headless CMS app.
+Configure the URLs of the webhooks used by the Headless CMS app.
 
 1. In the VTEX Admin, access **Storefront > Headless CMS**. 
 2. In the FastStore project interface, click on `Settings` (⚙️).
@@ -73,7 +45,7 @@ Let's configure the URLs of the webhooks used by the Headless CMS app.
 4. In **Build Webhook URL**, click `Add`.
 5. Enter the following value. _Replace the values between curly brackets according to your scenario._
 
-    ```sh
+    ```bash
     https://app.io.vtex.com/vtex.cms-builder-sf-jamstack/v1/{account}/master/build-releases
     ```
 
@@ -83,7 +55,7 @@ Let's configure the URLs of the webhooks used by the Headless CMS app.
 
 7. Fill in the **Preview URL** field with your production URL. This URL activates the button on Headless CMS so you can preview the changes made on a page. _Replace the values between curly brackets according to your scenario._
 
-### Step 3 - Communicating WebOps updates to the Headless CMS
+### Step 2 - Communicating WebOps updates to the Headless CMS
 
 If you are developing your FastStore project with CI/CD and Headless CMS, you must ensure that CI/CD is aware of every CMS update performed via the VTEX Admin. To do so, you must configure the WebOps webhooks responsible for communicating with the Headless CMS as in the following.
 


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Changes made in this PR:

- [FastStore CLI doc](docs/faststore/docs/getting-started/3-faststore-cli.mdx):  Add a 'Before you begin' section to mention the installation of Headless CMS, its dependencies and plugins.
- [Requirements doc](docs/faststore/docs/getting-started/requirements.mdx): Review the 'Install the Headless CMS and its dependencies' section and add the new section: 'Install Headless CMS plugins'.
- [Part 1: Configuring your VTEX account with the Headless CMS](docs/faststore/docs/headless-cms/1-configuring-the-vtex-account.mdx): Remove the instruction about Headless CMS plugins and add a new step in the 'Before you begin' about Headless CMS installation, its dependencies and plugins.