### PR TITLE
LOC-17719 - Windows user can't install Headless CMS plugins in 'my account' - troubleshooting documentation

### DIFF
--- a/docs/localization/i-cant-install-the-headless-cms-plugins-in-my-account.md
+++ b/docs/localization/i-cant-install-the-headless-cms-plugins-in-my-account.md
@@ -1,10 +1,10 @@
 ---
-title: I can’t install the Headless CMS plugins in my account
+title: "I can’t install the Headless CMS plugins in my account"
 excerpt: "Windows users may encounter the 'EPERM: operation not permitted' error during the installation of the Headless CMS plugin."
-slug: error-installing-headless-cms-plugins-on-windows'
+slug: "error-installing-headless-cms-plugins-on-windows"
 tags:
-  - headless-cms
-  - faststore
+    - headless-cms
+    - faststore
 ---
 
 If you are a Windows user, you may encounter the following error after [installing the Headless CMS plugin](https://developers.vtex.com/docs/guides/faststore/headless-cms-1-configuring-the-vtex-account#step-1-setting-up-the-command-line-environment):

--- a/docs/localization/i-cant-install-the-headless-cms-plugins-in-my-account.md
+++ b/docs/localization/i-cant-install-the-headless-cms-plugins-in-my-account.md
@@ -1,13 +1,13 @@
 ---
-title: "I can’t install the Headless CMS plugins in my account"
-excerpt: "Windows users can encounter the 'EPERM: operation not permitted' error during the installation of the Headless CMS plugin."
-slug: "error-installing-headless-cms-plugins-on-windows'"
+title: I can’t install the Headless CMS plugins in my account
+excerpt: "Windows users may encounter the 'EPERM: operation not permitted' error during the installation of the Headless CMS plugin."
+slug: error-installing-headless-cms-plugins-on-windows'
 tags:
-    - headless-cms
-    - faststore
+  - headless-cms
+  - faststore
 ---
 
-If you are a Windows user, you may find the following error after [installing the Headless CMS plugin](https://developers.vtex.com/docs/guides/faststore/headless-cms-1-configuring-the-vtex-account#step-1-setting-up-the-command-line-environment):
+If you are a Windows user, you may encounter the following error after [installing the Headless CMS plugin](https://developers.vtex.com/docs/guides/faststore/headless-cms-1-configuring-the-vtex-account#step-1-setting-up-the-command-line-environment):
 
 ```sh
 vtex plugins install cms
@@ -19,11 +19,11 @@ Installing plugin @vtex/cli-plugin-cms... failed
     Code: EPERM
 ```
 
-To solve this issue, enable the [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers) in your machine.
-Since FastStore projects rely on creating symbolic links (symlinks), this mode grants the necessary permissions and privileges, reducing the chance of errors during development.
+To solve this issue, enable [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers) in your machine.
+FastStore projects rely on creating symbolic links (symlinks), and this mode grants the necessary permissions and privileges to use them, which reduces the probability of encountering errors during development.
 
 > ⚠️ Running the FastStore project as an Administrator is not recommended.
 
-1. To enable Developer Mode, refer to Microsoft's official guide on [Enabling your device for development](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#accessing-settings-for-developers).
+1. To enable Developer Mode, refer to Microsoft's official guide [Enable your device for development](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#accessing-settings-for-developers).
 
-2. After enabling the mode, launch the Windows Terminal and run `vtex cms`. This will allow the system to create the symlinks necessary for running commands from the Headless CMS plugin.
+2. After enabling Developer Mode, launch Windows Terminal and run `vtex cms`. This will allow the system to create the necessary symlinks for running commands from the Headless CMS plugin.


### PR DESCRIPTION
Tracked in task [LOC-17719](https://vtex-dev.atlassian.net/browse/LOC-17719)

[LOC-17719]: https://vtex-dev.atlassian.net/browse/LOC-17719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ