### PR TITLE
Fix: Remove `vtex.admin-cms-graphql@0.x` dependency from hCMS docs

### DIFF
--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -40,13 +40,13 @@ If yes, proceed to check the [next requirement](https://developers.vtex.com/docs
 
     ![installation-message](https://vtexhelp.vtexassets.com/assets/docs/src/cms-install___7144afabf5a895ba92905926808507b2.png)
 
-5. Install Headless CMS dependencies by running the following command:
+5. Install the following Headless CMS dependency by running the following command:
 
     ```bash
     vtex install vtex.admin-cms-graphql-rc
     ```
 
-Once the app and its dependencies are installed, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins).
+Once the app and its dependency are installed, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins).
 
 ## Install Headless CMS plugins
 

--- a/docs/faststore/docs/getting-started/requirements.mdx
+++ b/docs/faststore/docs/getting-started/requirements.mdx
@@ -16,7 +16,6 @@ the integration between your project and Headless CMS is initiated.
 
 To prevent content duplication that could cause build failures during Onboarding, it is important to confirm the installation of the following apps in your account: 
 - `vtex.admin-cms@1.x`
-- `vtex.admin-cms-graphql`
 - `vtex.admin-cms-graphql-rc`
 
 To check whether you have them installed, follow the instructions below:
@@ -28,7 +27,7 @@ To check whether you have them installed, follow the instructions below:
     ```
 
 2. Run `vtex ls` to list all the installed apps in your account.
-3. Check if the `vtex.admin-cms@1.x`, `vtex.admin-cms-graphql`, and `vtex.admin-cms-graphql-rc` are in the list.
+3. Check if the `vtex.admin-cms@1.x` and `vtex.admin-cms-graphql-rc` are in the list.
 If yes, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins). If not, continue following these instructions.
 
 4. After logging into your account, install `vtex.admin-cms@1.x` by running the following command:
@@ -44,7 +43,7 @@ If yes, proceed to check the [next requirement](https://developers.vtex.com/docs
 5. Install Headless CMS dependencies by running the following command:
 
     ```bash
-    vtex install vtex.admin-cms-graphql vtex.admin-cms-graphql-rc
+    vtex install vtex.admin-cms-graphql-rc
     ```
 
 Once the app and its dependencies are installed, proceed to check the [next requirement](https://developers.vtex.com/docs/guides/faststore/getting-started-requirements#install-headless-cms-plugins).


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

The `vtex.admin-cms-graphql@0.x ` dependency is no longer used.
