### PR TITLE
EDU-14356: FastStore versions and support levels

### DIFF
--- a/docs/faststore/docs/getting-started/faststore-versions-and-support-levels.mdx
+++ b/docs/faststore/docs/getting-started/faststore-versions-and-support-levels.mdx
@@ -1,4 +1,64 @@
 ---
-title: 'FastStore versions and support levels'
+title: "FastStore versions and support levels"
 ---
 
+FastStore has two main versions: FastStore v1 and FastStore v2+. This document presents the key differences between these versions, their support levels, and guidelines for upgrading.
+
+## FastStore v1
+
+[FastStore v1](https://v1.faststore.dev/docs) was the first version of the framework. While it served as the foundation for FastStore, it is no longer actively maintained. New projects must use the latest version of FastStore.
+
+## FastStore v2+
+
+FastStore v2+ is the latest and most advanced version of the storefront solution. It includes all versions starting from v2 and introduces significant improvements over FastStore v1, such as:
+
+- **Simplified updates:** Stores are monitored for version updates with minimal friction, including automatic non-critical updates and a more efficient integration process.
+- **Separation of VTEX-managed code and store customizations:** Clear segmentation between VTEX and custom code to help in the debug process.
+- **CMS-first approach:** Headless CMS manages content updates (texts, images, links), while behavioral and UI component changes remain code-based, ensuring a structured workflow.
+- **Optimized performance and quality monitoring:** Continuous performance monitoring, with proactive measures to prevent deployments that fail to meet Lighthouse and quality standards.
+- **Semantic versioning:** FastStore v2+ uses [Semantic Versioning](https://semver.org/) to manage releases:
+  - **Majors:** Introduce breaking changes, including incompatible API changes.
+  - **Minors:** Introduce backward-compatible features.
+  - **Patches:** Include backward-compatible bug fixes.
+
+## Key differences between FastStore versions
+
+One of the main changes from FastStore v1 to FastStore v2+ is the separation between VTEX code and store-specific customizations. This separation introduced the [`core`](https://developers.vtex.com/docs/guides/faststore/project-structure-overview#packagejson) package for VTEX code and reserved the `/src` folder for store-specific customizations. Below are the key differences between the versions:
+
+### Packages
+
+| Package name    | FastStore v1 | FastStore v2 | FastStore v3 |
+| --------------- | ------------ | ------------ | ------------ |
+| `api`           | ✅           | ✅           | ✅           |
+| `cli`           | ✅           | ✅           | ✅           |
+| `components`    | ✅           | ✅           | ✅           |
+| `core`          | ❌           | ✅           | ✅           |
+| `graphql-utils` | ✅           | ✅           | ✅           |
+| `lighthouse`    | ✅           | ✅           | ✅           |
+| `sdk`           | ✅           | ✅           | ✅           |
+| `styles`        | ✅           | ❌           | ❌           |
+| `ui`            | ✅           | ✅           | ✅           |
+
+### Other aspects
+
+| **Aspect**        | **FastStore v1** | **FastStore v2** | **FastStore v3** |
+| ------------  | ------------ | ------------ | ------------ |
+| **Documentation** | [FastStore v1 Portal](https://v1.faststore.dev/) | [Developers Portal](https://developers.vtex.com/docs/guides/faststore) | [Developers Portal](https://developers.vtex.com/docs/guides/faststore) |
+| **Project onboarding**   | [Cloning the FastStore starter repository](https://v1.faststore.dev/quickstart). | Onboarding app | [WebOps](https://developers.vtex.com/docs/guides/faststore/1-onboarding-overview)       |
+| **Development framework** | [Gatsby](https://www.gatsbyjs.com/docs/) / [Next.js](https://nextjs.org/docs) | [Next.js](https://nextjs.org/docs) | [Next.js](https://nextjs.org/docs)                                    |
+
+## Support levels
+
+Different levels of support are available depending on the FastStore version. The following table details the status, support availability, support availability, and recommendations for new projects for each version.
+
+| **Criteria** | **FastStore v1** | **FastStore v2+** |
+|-------------|----------------|--------------------|
+| **Status** | No longer updated. | Actively maintained. |
+| **Support** | Limited support. Only bugs and vulnerabilities related to public VTEX APIs are addressed. | Full support. |
+| **New Projects** | Not supported. Only FastStore v2+ is available for new projects. | Recommended for all new storefront implementations. |
+
+If you have any questions about the level of support provided for different FastStore versions, [open a ticket](https://support.vtex.com/hc/pt-br/requests) with the VTEX Support team.
+
+## Upgrade between FastStore versions
+
+Before upgrading to a new FastStore version, consult VTEX to ensure compatibility and a smooth transition. For assistance, [open a ticket](https://support.vtex.com/hc/pt-br/requests) with the VTEX Support team.

--- a/docs/faststore/docs/getting-started/faststore-versions-and-support-levels.mdx
+++ b/docs/faststore/docs/getting-started/faststore-versions-and-support-levels.mdx
@@ -1,0 +1,4 @@
+---
+title: 'FastStore versions and support levels'
+---
+

--- a/docs/faststore/docs/getting-started/faststore-versions-and-support-levels.mdx
+++ b/docs/faststore/docs/getting-started/faststore-versions-and-support-levels.mdx
@@ -57,8 +57,8 @@ Different levels of support are available depending on the FastStore version. Th
 | **Support** | Limited support. Only bugs and vulnerabilities related to public VTEX APIs are addressed. | Full support. |
 | **New Projects** | Not supported. Only FastStore v2+ is available for new projects. | Recommended for all new storefront implementations. |
 
-If you have any questions about the level of support provided for different FastStore versions, [open a ticket](https://support.vtex.com/hc/pt-br/requests) with the VTEX Support team.
+If you have any questions about the level of support provided for different FastStore versions, [open a ticket](https://help.vtex.com/en/support) with the VTEX Support team.
 
 ## Upgrade between FastStore versions
 
-Before upgrading to a new FastStore version, consult VTEX to ensure compatibility and a smooth transition. For assistance, [open a ticket](https://support.vtex.com/hc/pt-br/requests) with the VTEX Support team.
+Before upgrading to a new FastStore version, consult VTEX to ensure compatibility and a smooth transition. For assistance, [open a ticket](https://help.vtex.com/en/support) with the VTEX Support team.

--- a/docs/faststore/docs/getting-started/overview.mdx
+++ b/docs/faststore/docs/getting-started/overview.mdx
@@ -9,7 +9,13 @@ In this Getting Started track, you will build and deploy a FastStore storefront 
 
 <Flex>
   <WhatsNextCard
-    title="0. Requirements"
+    title="FastStore versions and support levels"
+    description="Understand the key differences between FastStore versions, their support levels, and guidelines for upgrading."
+    linkTo="https://developers.vtex.com/docs/guides/faststore/getting-started-faststore-versions-and-support-levels"
+    linkTitle="See more"
+  />
+  <WhatsNextCard
+    title="Requirements"
     description="Ensure that you have met all the necessary requirements before beginning your FastStore project."
     linkTo="https://developers.vtex.com/docs/guides/faststore/getting-started-requirements"
     linkTitle="See more"

--- a/docs/guides/faststore/faststore.md
+++ b/docs/guides/faststore/faststore.md
@@ -16,6 +16,8 @@ It supports integration with [Headless CMS](https://developers.vtex.com/docs/gui
 | **Stability** | Built to be stable and avoid crashes, so your store doesn't lose sales due to provider issues.  |
 | **Analytics/SEO** | Works with analytics tools to understand store customers and with SEO tools to improve store visibility in search results. |
 
+> ⚠ For a detailed understanding of the key differences between FastStore versions, their support levels, and guidelines for upgrading, please refer to the [FastStore versions and support levels](https://developers.vtex.com/docs/guides/faststore/versions-support) guide.
+
 ## FastStore architecture
 
   ```mermaid

--- a/docs/guides/faststore/faststore.md
+++ b/docs/guides/faststore/faststore.md
@@ -16,7 +16,7 @@ It supports integration with [Headless CMS](https://developers.vtex.com/docs/gui
 | **Stability** | Built to be stable and avoid crashes, so your store doesn't lose sales due to provider issues.  |
 | **Analytics/SEO** | Works with analytics tools to understand store customers and with SEO tools to improve store visibility in search results. |
 
-> ⚠ For a detailed understanding of the key differences between FastStore versions, their support levels, and guidelines for upgrading, please refer to the [FastStore versions and support levels](https://developers.vtex.com/docs/guides/faststore/versions-support) guide.
+> ⚠ For a detailed understanding of the key differences between FastStore versions, their support levels, and guidelines for upgrading, please refer to the [FastStore versions and support levels](https://developers.vtex.com/docs/guides/faststore/getting-started-faststore-versions-and-support-levels) guide.
 
 ## FastStore architecture
 


### PR DESCRIPTION
#### Types of changes
- [x] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Updates on the navbar: the idea is to have a new guide inside the ['Getting started](https://developers.vtex.com/docs/guides/faststore/getting-started-overview)' (PR: `navigation.json`: https://github.com/vtexdocs/devportal/pull/909). Once we have the guide 'Upgrading to FastStore latest version', the idea is to have the 'Upgrading' category and inside it has the 'FastStore versions and support levels'
 and the 'Upgrading to FastStore latest version' guides.