### PR TITLE
EDU-13795: FastStore `useCart` - Add  LOC review

### DIFF
--- a/docs/faststore/docs/sdk/cart/use-cart.mdx
+++ b/docs/faststore/docs/sdk/cart/use-cart.mdx
@@ -1,0 +1,51 @@
+---
+title: "useCart"
+---
+
+The `useCart` hook gives access to the `Cart` object and helper functions for managing the shopping cart. The hook allows adding, removing, and updating items in the cart and checking its status (e.g., whether it is empty or validating).
+
+## Import
+
+```tsx
+import { useCart } from '@faststore/sdk'
+```
+
+## Usage
+
+The following example demonstrates how the `items` array is mapped to display the name and price of each item in the cart:
+
+```tsx
+function Cart () {
+  const { items, isValidating } = useCart()
+
+  return (
+    <>
+      {items.map(item => (
+        <div>name: {item.itemOffered.name}</div>
+        <div>Price: {item.price}</div>
+      ))}
+      <a href="/checkout">{isValidating ? 'loading...' : 'Checkout'}</a>
+    </>
+  )
+}
+```
+
+The `isValidating` flag is used to show a loading state while the cart is being validated.
+
+## API reference
+
+The `useCart` hook returns an object with the following properties and functions:
+
+| Variable name | Type | Description |
+| -------- | --------------- | ------------ |
+| `addItem` | `(item: T) => void` | Adds an item to the cart. |
+| `emptyCart` | `() => void` | Removes all items from the cart. |
+| `getItem` | `(id: string) => T | undefined` | Retrieves an item from the cart by its `id`. Returns `undefined` if not found. |
+| `id` | `string` | Gets the cart's unique identifier. |
+| `inCart` | `(id: string) => boolean` | Checks if an item with the given `id` exists in the cart. |
+| `isEmpty` | `boolean` | Returns `true` if the cart is empty. |
+| `isValidating` | `boolean` | Returns `true` if the cart is being validated (e.g., syncing with a server). |
+| `items` | `Item[]` | Gets the current items in the cart. |
+| `removeItem` | `(id: string) => void` | Removes an item from the cart by its `id`. |
+| `setCart` | `(cart: Cart) => void` | Replaces the current cart with a new one. |
+| `updateItemQuantity` | `(id: string, quantity: number) => void` | Updates the quantity of a given item in the cart. |

--- a/docs/faststore/docs/sdk/overview.mdx
+++ b/docs/faststore/docs/sdk/overview.mdx
@@ -16,13 +16,13 @@ The SDK is organized into four modules with specific properties and behaviors. T
 
 ## Cart
 
-The Cart module controls the state of the shopping cart data structure in the shopper's browser. You can use it to add items to the cart, remove items, and clear the cart, among other tasks. {/* Learn more about [Cart](LINK) module. */}
+The Cart module controls the state of the shopping cart data structure in the shopper's browser. You can use it to add items to the cart, remove items, and clear the cart, among other tasks. Learn more about [Cart](https://developers.vtex.com/docs/guides/faststore/cart-overview) module.
 
 > ℹ️ Learn more about validating the cart in the shopper browser against the information in the platform with [FastStore API mutations](https://developers.vtex.com/docs/guides/faststore/schema-mutations#cart).
 
 ## Session
 
-The Session module manages the state of session information in the shopper browser. This includes currency, channel, localization, and shopper information. {/* Learn more about the [Session module](LINK) data structure and usage. */}
+The Session module manages the state of session information in the shopper browser. This includes currency, channel, localization, and shopper information. Learn more about the [Session module](https://developers.vtex.com/docs/guides/faststore/sdk-session) data structure and usage.
 
 > ℹ️ Learn more about validating the cart in the shopper browser against the information in the platform with [FastStore API mutations](https://developers.vtex.com/docs/guides/faststore/schema-mutations#session).
 
@@ -30,7 +30,7 @@ The Session module manages the state of session information in the shopper brows
 
 The Search module offers functions for implementing a faceted search based on URL parameters. Whenever a shopper searches your store or changes the selected facets, the search module generates a unique and serialized URL and then directs the user to that URL.
 
-{/* Learn more about how to use the [Search module](LINK) in your project. */}
+Learn more about how to use the [Search module](https://developers.vtex.com/docs/guides/faststore/search-overview) in your project.
 
 ## Analytics
 


### PR DESCRIPTION
#### Types of changes

This PR adds the `useCart` guide reviewed by the Localization team and also updates the [SDK overview](https://developers.vtex.com/docs/guides/faststore/sdk-overview) with the links for each SDK module.

- [x] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

`navigation.json`: https://github.com/vtexdocs/devportal/pull/930
