### PR TITLE
Fix crowdin.yml file naming output

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,5 @@
 files:
   - source: /docs/localization/*.md
-    translation: /%original_path%/%original_file_name%_%two_letters_code%
+    translation: /%original_path%/%original_file_name%.%file_extension%
   - source: /docs/localization/*.mdx
-    translation: /%original_path%/%original_file_name%_%two_letters_code%
+    translation: /%original_path%/%original_file_name%.%file_extension%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,5 @@
 files:
   - source: /docs/localization/*.md
-    translation: /%original_path%/%original_file_name%.%file_extension%
+    translation: /%original_path%/%original_file_name%
   - source: /docs/localization/*.mdx
-    translation: /%original_path%/%original_file_name%.%file_extension%
+    translation: /%original_path%/%original_file_name%


### PR DESCRIPTION
It fixes a part of the crowdin.yml file that was generating files with incorrect extensions.