### PR TITLE
feat: add changelog action and conventional commits

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,39 @@
+name: Generate Changelog
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  generate-changelog:
+    if: github.event.pull_request.merged == true || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm install
+        
+      - name: Set Git identity
+        run: |
+          git config user.name "julia-rabello"
+          git config user.email "julia.alexandre@vtex.com"
+
+      - name: Generate Changelog
+        run:
+            npm run release
+
+      - name: Push Changes
+        run: |
+          git push --follow-tags origin main

--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,46 @@
+{
+    "skip": {
+        "bump": false,
+        "commit": false,
+        "tag": false
+    },
+    "types": [
+        {
+            "type": "new",
+            "section": "✨ New documentation"
+        },
+        {
+            "type": "update",
+            "section": "📝 Documentation updates"
+        },
+        {
+            "type": "fix",
+            "section": "🔧 Fixes and improvements"
+        },
+        {
+            "type": "remove",
+            "section": "🗑️ Removed content"
+        },
+        {
+            "type": "loc",
+            "section": "🌐 Translation updates"
+        },
+        {
+            "type": "media",
+            "section": "🖼️ Media updates"
+        },
+        {
+            "type": "docs",
+            "section": "📄 Repository documentation"
+        },
+        {
+            "type": "test",
+            "section": "🧪 Tests",
+            "hidden": true
+        },
+        {
+            "type": "feat",
+            "section": "⚙️ Repository features"
+        }
+    ]
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,49 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    plugins: ['commitlint-plugin-function-rules'],
+    rules: {
+        'type-enum': [
+            2,
+            'always',
+            ['new', 'fix', 'media', 'update', 'remove', 'loc', 'docs', 'feat', 'test']
+        ],
+        'scope-case': [2, 'always', 'kebab-case'],
+        'scope-empty': [
+            2,
+            'never',
+            ['new'] // "new" requires scope
+        ],
+        'scope-empty': [
+            0,
+            'always',
+            ['fix', 'media'] // "fix" and "media" allow optional scopes
+        ],
+        'function-rules/scope-enum': [
+            2,
+            'always',
+            (parsed) => {
+                const allowedScopes = {
+                    new: ['guide', 'troubleshooting', 'release-notes'],
+                    fix: ['typo', 'broken-link', 'markdown']
+                };
+
+                const { type, scope } = parsed;
+
+                // Only validate scopes for "new" and "fix"
+                if (!allowedScopes[type]) return [true];
+
+                // Validate "new" scopes
+                if (type === 'new' && !allowedScopes.new.includes(scope)) {
+                    return [false, `new() scope must be one of: ${allowedScopes.new.join(', ')}`];
+                }
+
+                // Validate "fix" scopes (if used)
+                if (type === 'fix' && scope && !allowedScopes.fix.includes(scope)) {
+                    return [false, `fix() scope must be one of: ${allowedScopes.fix.join(', ')}`];
+                }
+
+                return [true];
+            }
+        ]
+    }
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,19 @@
   "repository": "https://github.com/vtexdocs/dev-portal-content",
   "author": "Bruno Amui <bruno.amui@vtex.com.br>",
   "license": "MIT",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "release": "standard-version",
+    "release:minor": "standard-version --release-as minor",
+    "release:patch": "standard-version --release-as patch",
+    "release:major": "standard-version --release-as major"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.0",
+    "@commitlint/config-conventional": "^19.8.0",
+    "commitlint-plugin-function-rules": "^4.0.1",
+    "standard-version": "^9.5.0"
+  },
   "dependencies": {
     "textlint": "^13.1.0",
     "textlint-rule-write-good": "^2.0.0"


### PR DESCRIPTION
Adding an automatic changelog based on this [RFC](https://docs.google.com/document/d/1gz90RrWEH3jRs3Tk67k7GLXGcXacmI6JGfelJNUfKq8/edit?tab=t.0).

Commit rules:

| Commit type | When to use | Allowed scopes |
| :---- | :---- | :---- |
| `new` | Add new documentation pages. Adding a scope is required (e.g. `new(guide): catalog overview`) | `guide`, `troubleshooting`, `release-notes` |
| `fix` | Fix typos, broken links, or minor corrections. Adding a scope is optional (e.g. `fix(broken-link): learn more`, `fix: marketplace name`). | `typo`, `broken-link, markdown` |
| `update` | Update existing documentation content | N/A |
| `remove` | Remove deprecated/outdated documentation pages | N/A |
| `loc` | Add or update translations/localization content | N/A |
| `media` | Add, update or remove images, GIFs, or videos | N/A |
| `docs` | Update repository documentation files (README.md) | N/A |
| `test` | Internal testing changes (hidden from changelog) | N/A |
| `feat` | New features and actions within the repository | N/A |

Tested in the [action-tester](https://github.com/vtexdocs/action-tester/blob/main/CHANGELOG.md) repository.