### PR TITLE
Add "Check frontmatter" GitHub Action

### DIFF
--- a/.github/scripts/check_frontmatter.py
+++ b/.github/scripts/check_frontmatter.py
@@ -1,0 +1,169 @@
+import os
+import sys
+from github import Github
+import yaml
+import re
+import json
+
+# Get environment variables
+GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+GITHUB_REPOSITORY = os.getenv('GITHUB_REPOSITORY')
+GITHUB_EVENT_PATH = os.getenv('GITHUB_EVENT_PATH')
+
+if not (GITHUB_TOKEN and GITHUB_REPOSITORY and GITHUB_EVENT_PATH):
+    print('Missing required environment variables.')
+    sys.exit(1)
+
+# Load event data
+event = {}
+with open(GITHUB_EVENT_PATH, 'r') as f:
+    event = json.load(f)
+
+pr_number = event.get('pull_request', {}).get('number')
+if not pr_number:
+    print('Not a pull request event.')
+    sys.exit(0)
+
+g = Github(GITHUB_TOKEN)
+repo = g.get_repo(GITHUB_REPOSITORY)
+pr = repo.get_pull(pr_number)
+
+def plural_list(list):
+    return 's' if len(list) != 1 else ''
+
+# Get changed Markdown files in the PR (only in 'docs/guides', 'docs/release-notes', 'docs/troubleshooting', and 'docs/faststore' folders)
+changed_files = [f for f in pr.get_files() if (
+    f.filename.endswith(('.md', '.mdx'))
+    and f.filename.startswith(('docs/guides/', 'docs/release-notes/', 'docs/troubleshooting/', 'docs/faststore/'))
+)]
+
+print(f"Found {len(changed_files)} markdown file{plural_list(changed_files)} in PR:")
+
+error_found = False
+frontmatters = {}
+for f in changed_files:
+    print(f"- {f.filename}")
+    content = repo.get_contents(f.filename, ref=pr.head.ref)
+    text = content.decoded_content.decode('utf-8')
+
+    # Extract frontmatter
+    if text.startswith('---'):
+        end = text.find('\n---', 3)
+        if end != -1:
+            frontmatter = text[3:end+1].strip()
+            try:
+                fm_dict = yaml.safe_load(frontmatter)
+                if not isinstance(fm_dict, dict):
+                    print(' \n')
+                    print(f"ERROR: Frontmatter in '{f.filename}' is not a valid YAML dictionary.")
+                    error_found = True
+                    fm_dict = {}
+            except Exception as e:
+                print(f"ERROR: Failed to parse YAML frontmatter in '{f.filename}': {e}")
+                error_found = True
+                fm_dict = {}
+            frontmatters[f.filename] = fm_dict
+            print(' \n')
+            print(f"Frontmatter dict for '{f.filename}':\n{{")
+            for k, v in fm_dict.items():
+                print(f"  {k}: {v}")
+            print('}')
+
+            # Validate formatting in present fields
+            iso8601_regex = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+            for key, value in fm_dict.items():
+                if key == 'title':
+                    if not isinstance(value, str) or not value:
+                        print(f"ERROR: '{key}' in '{f.filename}' must be a non-empty string.")
+                        error_found = True
+                    continue
+                if key == 'excerpt':
+                    if not isinstance(value, str):
+                        print(f"ERROR: '{key}' in '{f.filename}' must be a string.")
+                        error_found = True
+                    continue
+                if key == 'slug':
+                    if not (isinstance(value, str) and re.fullmatch(r'[a-z0-9\-]+', value)):
+                        print(f"ERROR: 'slug' in '{f.filename}' must contain only lowercase letters, numbers, and hyphens.")
+                        error_found = True
+                    if value!= f.filename.split('/')[-1].replace('.md', ''):
+                        print(f"ERROR: 'slug' in '{f.filename}' must match the filename without extension.")
+                        error_found = True
+                    continue
+                if key == 'hidden':
+                    if not isinstance(value, bool):
+                        print(f"ERROR: 'hidden' in '{f.filename}' must be a boolean (true or false).")
+                        error_found = True
+                    continue
+                if key == 'createdAt':
+                    if not (isinstance(value, str) and iso8601_regex.match(value)):
+                        print(f"ERROR: '{key}' in '{f.filename}' must be a string in ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ).")
+                        error_found = True
+                    continue
+                if key == 'updatedAt':
+                    if not (isinstance(value, str) and iso8601_regex.match(value)):
+                        print(f"ERROR: '{key}' in '{f.filename}' must be a string in ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ).")
+                        error_found = True
+                    continue
+                if key == 'tags':
+                    if not (isinstance(value, list)):
+                        print(f"ERROR: 'tags' in '{f.filename}' must be a list.")
+                        error_found = True
+                    continue
+                if key == 'type':
+                    allowed_types = {"added", "deprecated", "fixed", "improved", "info", "removed"}
+                    if not (isinstance(value, str) and value in allowed_types):
+                        print(f"ERROR: 'type' in '{f.filename}' must be one of: {', '.join(allowed_types)}.")
+                        error_found = True
+
+            # Validate mandatory fields for all doc types
+            if 'title' not in fm_dict:
+                print(f"ERROR: '{f.filename}' must have a 'title' field in frontmatter.")
+                error_found = True
+
+            # Validate fields by doc type using folder structure
+            def not_present_keys(keys, dict):
+                return [key for key in keys if key not in dict]
+
+            rn_mandatory_fields = ['type', 'slug', 'excerpt', 'hidden', 'createdAt', 'updatedAt']
+            guides_mandatory_fields = ['slug', 'excerpt', 'hidden', 'createdAt', 'updatedAt']
+            ts_mandatory_fields = ['tags', 'slug', 'excerpt', 'hidden', 'createdAt', 'updatedAt']
+
+            if f.filename.startswith('docs/release-notes'):
+                missing_fields = not_present_keys(rn_mandatory_fields, fm_dict)
+                if missing_fields:
+                    print(f"ERROR: '{f.filename}' release note missing {missing_fields} field{plural_list(missing_fields)} in frontmatter.")
+                    error_found = True
+            else:
+                if 'type' in fm_dict:
+                    print(f"ERROR: '{f.filename}' should not have a 'type' field in frontmatter for non-release notes.")
+                    error_found = True
+
+            if f.filename.startswith('docs/guides'):
+                missing_fields = not_present_keys(guides_mandatory_fields, fm_dict)
+                if missing_fields:
+                    print(f"ERROR: '{f.filename}' guide missing {missing_fields} field{plural_list(missing_fields)} in frontmatter.")
+                    error_found = True
+
+            if f.filename.startswith('docs/troubleshooting'):
+                missing_fields = not_present_keys(ts_mandatory_fields, fm_dict)
+                if missing_fields:
+                    print(f"ERROR: '{f.filename}' troubleshooting missing {missing_fields} field{plural_list(missing_fields)} in frontmatter.")
+                    error_found = True
+
+            if f.filename.startswith('docs/faststore'):
+                if fm_dict.keys() != {'title'}:
+                    print(f"ERROR: '{f.filename}' FastStore docs must have only 'title' field in frontmatter.")
+                    error_found = True
+
+        else:
+            print(f"ERROR: '{f.filename}' frontmatter not closed with '---'.")
+            error_found = True
+    else:
+        print(f"ERROR: '{f.filename}' does not start with frontmatter block ('---').")
+        error_found = True
+
+if error_found:
+    print(' \n')
+    print("Frontmatter errors found. Failing the action.")
+    sys.exit(1)

--- a/.github/scripts/check_frontmatter.py
+++ b/.github/scripts/check_frontmatter.py
@@ -63,10 +63,14 @@ for f in changed_files:
                 errors.append(f"Failed to parse YAML frontmatter: {e}")
                 error_found = True
                 fm_dict = {}
+
+            print(fm_dict)
             frontmatters[f.filename] = fm_dict
 
-            # Validate formatting in present fields
+            # Regular expression for ISO 8601 date format (YYYY-MM-DDThh:mm:ss.sssZ)
             iso8601_regex = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+            # Validate formatting in present fields
             for key, value in fm_dict.items():
                 if key == 'title':
                     if not isinstance(value, str) or not value:
@@ -121,9 +125,9 @@ for f in changed_files:
             def not_present_keys(keys, dict):
                 return [key for key in keys if key not in dict]
 
-            rn_mandatory_fields = ['type', 'slug', 'excerpt', 'hidden', 'createdAt', 'updatedAt']
-            guides_mandatory_fields = ['slug', 'excerpt', 'hidden', 'createdAt', 'updatedAt']
-            ts_mandatory_fields = ['tags', 'slug', 'excerpt', 'hidden', 'createdAt', 'updatedAt']
+            rn_mandatory_fields = ['type', 'slug', 'excerpt', 'hidden', 'createdAt']
+            guides_mandatory_fields = ['slug', 'excerpt', 'hidden', 'createdAt']
+            ts_mandatory_fields = ['tags', 'slug', 'excerpt', 'hidden', 'createdAt']
 
             if f.filename.startswith('docs/release-notes'):
                 missing_fields = not_present_keys(rn_mandatory_fields, fm_dict)
@@ -145,11 +149,6 @@ for f in changed_files:
                 missing_fields = not_present_keys(ts_mandatory_fields, fm_dict)
                 if missing_fields:
                     errors.append(f"Troubleshooting missing field{plural_list(missing_fields)}: {missing_fields}.")
-                    error_found = True
-
-            if f.filename.startswith('docs/faststore'):
-                if fm_dict.keys() != {'title'}:
-                    errors.append(f"FastStore docs must have only 'title' field in frontmatter.")
                     error_found = True
 
         else:

--- a/.github/scripts/check_frontmatter.py
+++ b/.github/scripts/check_frontmatter.py
@@ -86,7 +86,7 @@ for f in changed_files:
                     if not (isinstance(value, str) and re.fullmatch(r'[a-z0-9\-]+', value)):
                         print(f"ERROR: 'slug' in '{f.filename}' must contain only lowercase letters, numbers, and hyphens.")
                         error_found = True
-                    if value!= f.filename.split('/')[-1].replace('.md', ''):
+                    if value!= f.filename.split('/')[-1].replace('.mdx', '').replace('.md', ''):
                         print(f"ERROR: 'slug' in '{f.filename}' must match the filename without extension.")
                         error_found = True
                     continue

--- a/.github/workflows/check-frontmatter.yml
+++ b/.github/workflows/check-frontmatter.yml
@@ -3,6 +3,15 @@ name: Check frontmatter
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/guides/**/*.md'
+      - 'docs/guides/**/*.mdx'
+      - 'docs/release-notes/**/*.md'
+      - 'docs/release-notes/**/*.mdx'
+      - 'docs/troubleshooting/**/*.md'
+      - 'docs/troubleshooting/**/*.mdx'
+      - 'docs/faststore/**/*.md'
+      - 'docs/faststore/**/*.mdx'
 
 jobs:
   review-frontmatter:

--- a/.github/workflows/check-frontmatter.yml
+++ b/.github/workflows/check-frontmatter.yml
@@ -1,0 +1,23 @@
+name: Check frontmatter
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review-frontmatter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install PyGithub
+        run: pip install PyGithub
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Run frontmatter review script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/frontmatter_review.py

--- a/.github/workflows/check-frontmatter.yml
+++ b/.github/workflows/check-frontmatter.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run frontmatter review script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python .github/scripts/frontmatter_review.py
+        run: python .github/scripts/check_frontmatter.py


### PR DESCRIPTION
Add "Check frontmatter" GitHub Action to validate frontmatter in Markdown files.

## Validation rules

### Field types

The action validates the frontmatter with the following fields:

|Field|Type|
|-|-|
|`title`|Non-empty `string`|
|`slug`|`string` with only lowercase letters, hyphens, and numbers. Must be equal the filename without extension.|
|`excerpt`|`string`|
|`createdAt`|`string` with ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ)|
|`updatedAt`|`string` with ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ)|
|`hidden`|`boolean`|
|`tags`|`list`|
|`type`|`string` with release note type. Must be one of: added, deprecated, fixed, improved, info, removed.|

### Documentation types

The action validates the frontmatter fields for each documentation type as below:

|Field|Release note|Guide|Troubleshooting|FastStore|
|-|:-:|:-:|:-:|:-:|
|`title`    |⭕|⭕|⭕|⭕|
|`slug`     |⭕|⭕|⭕|✅|
|`excerpt`  |⭕|⭕|⭕|✅|
|`createdAt`|⭕|⭕|⭕|✅|
|`updatedAt`|✅|✅|✅|✅|
|`hidden`   |⭕|⭕|⭕|✅|
|`tags`     |✅|✅|⭕|✅|
|`type`     |⭕|❌|❌|❌|

Legend:

- ⭕: Mandatory
- ✅: Allowed
- ❌: Prohibited

> [!NOTE]
> Other fields not listed are all allowed and will not be verified.