### PR TITLE
EDU-15253: Add new design tokens to `SearchProducts`

### DIFF
--- a/docs/faststore/components/molecules/search-products.mdx
+++ b/docs/faststore/components/molecules/search-products.mdx
@@ -229,7 +229,20 @@ All search product related components support all attributes also supported by t
   />
 </TokenTable>
 
-#### Item Image
+#### Item control
+
+<TokenTable>
+  <TokenRow
+    token="--fs-search-product-item-control-actions-gap"
+    value="var(--fs-spacing-1)"
+  />
+  <TokenRow
+    token="--fs-search-product-item-control-input-width"
+    value="4.625rem"
+  />
+</TokenTable>
+
+#### Item image
 
 <TokenTable>
   <TokenRow
@@ -243,7 +256,7 @@ All search product related components support all attributes also supported by t
   <TokenRow token="--fs-search-product-item-image-size" value="3.5rem" />
 </TokenTable>
 
-#### Item Title
+#### Item title
 
 <TokenTable>
   <TokenRow
@@ -262,7 +275,7 @@ All search product related components support all attributes also supported by t
   />
 </TokenTable>
 
-#### Item Price
+#### Item price
 
 <TokenTable>
   <TokenRow


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Add new design tokens for the [`SearchProducts`](https://developers.vtex.com/docs/guides/faststore/molecules-search-products#design-tokens) based on the following PR: https://github.com/vtex/faststore/pull/2860