### PR TITLE
EDU-12948 - Add min and max value for field

### DIFF
--- a/docs/guides/Orders/orders-feed.md
+++ b/docs/guides/Orders/orders-feed.md
@@ -196,6 +196,8 @@ The properties of this object define the behavior of feed items once they are in
 
 - `MessageRetentionPeriodInSeconds` - Items will be excluded from the feed — even if they aren't committed — when they stay in the feed longer than the retention period defined in this field.
 
+>⚠️ The minimum value for the `messageRetentionPeriodInSeconds` field is `345600` and the maximum is `1209600`.
+
 ### Other fields
 
 There are also a couple of other fields that give us some information about the state of the field:


### PR DESCRIPTION
Add minimum and maximum value for `messageRetentionPeriodInSeconds` field. Refers to [EDU-12948](https://vtex-dev.atlassian.net/browse/EDU-12948).

#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [x] Improvement (make a documentation even better)
- [ ] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)


[EDU-12948]: https://vtex-dev.atlassian.net/browse/EDU-12948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ