### PR TITLE
EDU-16081: Fix step 6 in Configuring external DNS guide

### DIFF
--- a/docs/faststore/docs/go-live/1-configuring-external-dns.mdx
+++ b/docs/faststore/docs/go-live/1-configuring-external-dns.mdx
@@ -5,7 +5,7 @@ createdAt: '2024-01-01T00:00:00Z'
 updatedAt: '2025-09-23T00:00:00Z'
 ---
 
-In this guide, you will learn how to configure external domains for your **FastStore** and **VTEX** websites. The process involves the following steps:
+In this guide, you will learn how to point your custom domain to your **FastStore** website and configure it in VTEX for a complete setup. The process involves the following steps:
 
    - Setting up your external DNS provider to point your custom domain to your VTEX website. You can buy custom domains from any **domain registration platform**.
    - Configuring your custom domains in **VTEX Account Settings**.


### PR DESCRIPTION
#### Types of changes
- [ ] New content (guides, endpoints, app documentation)
- [ ] Improvement (make a documentation even better)
- [x] Fix (fix a documentation error)
- [ ] Spelling and grammar accuracy (self-explanatory)

Correções:

-  Adicionar step 6 antes do step 5. Isso porque o fluxo de configuração da CDN valida o domínio diretamente no WebOps. Caso o domínio ainda não esteja registrado, a migração falha. Portanto, o domínio precisa já estar cadastrado no WebOps antes de iniciar o processo de migração na CDN.
- Gramaticais
