### PR TITLE
fix(ci): handle non-ASCII file paths in index-documents workflow

### DIFF
--- a/.github/workflows/index-documents.yml
+++ b/.github/workflows/index-documents.yml
@@ -35,7 +35,7 @@ jobs:
           if [ "${{ github.event.inputs.full_reindex }}" = "true" ] || [ "${{ github.event_name }}" = "workflow_dispatch" -a "${{ github.event.inputs.full_reindex }}" = "true" ]; then
             FILES=$(find docs -name '*.md' -type f | jq -R -s -c 'split("\n") | map(select(length > 0))')
           else
-            FILES=$(git diff --name-only --diff-filter=ACMR HEAD~1 HEAD -- 'docs/**/*.md' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            FILES=$(git -c core.quotepath=false diff --name-only --diff-filter=ACMR HEAD~1 HEAD -- 'docs/**/*.md' | jq -R -s -c 'split("\n") | map(select(length > 0))')
           fi
           echo "files=$FILES" >> $GITHUB_OUTPUT
           echo "count=$(echo $FILES | jq length)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fix indexing failures for documents with accented characters in file paths (ñ, ã, ó).

**Root cause**: `git diff --name-only` with default `core.quotepath=true` outputs non-ASCII paths with literal double quotes and octal escapes. The indexing API receives these quoted paths and fails to fetch them from GitHub (404).

**Fix**: `git -c core.quotepath=false` — outputs raw UTF-8 paths.

Same fix applied in vtexdocs/vtexdocs-mcp-app#34 and vtexdocs/help-center-content#661.