### PR TITLE
Add AI-Assisted Development documentation (MCP + Skills)

### DIFF
--- a/docs/guides/AI-Assisted-Development/ai-assisted-development-overview.md
+++ b/docs/guides/AI-Assisted-Development/ai-assisted-development-overview.md
@@ -1,0 +1,62 @@
+---
+title: "AI-Assisted Development"
+slug: "ai-assisted-development-overview"
+hidden: false
+createdAt: "2026-04-09T19:00:00.000Z"
+updatedAt: "2026-04-09T19:00:00.000Z"
+excerpt: "Learn how VTEX AI-powered tools help developers build on the platform faster with real-time documentation access and domain-specific AI skills."
+seeAlso:
+ - "/docs/guides/vtex-developer-mcp"
+ - "/docs/guides/vtex-skills"
+hidePaginationPrevious: false
+hidePaginationNext: false
+---
+
+VTEX is a composable and complete commerce platform, and building on it means working with a large surface area of APIs, frameworks, and platform-specific constraints. Two complementary tools help your AI coding assistant navigate that surface: the **VTEX Developer MCP** and **VTEX Skills**.
+
+The VTEX Developer MCP gives AI assistants real-time access to VTEX documentation and API references. VTEX Skills encodes platform-specific patterns, constraints, and best practices directly into your AI agent. Together, they give your assistant both current knowledge and domain expertise — so it can look things up and know how to build correctly.
+
+## VTEX Developer MCP
+
+The `@vtex/developer-mcp` package is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects AI coding assistants to VTEX documentation and API specifications. It exposes four tools: documentation search, document fetching, endpoint search, and endpoint detail lookup.
+
+No API key or authentication is required. Run it with a single command:
+
+```sh
+npx -y @vtex/developer-mcp
+```
+
+It works with Cursor, VS Code (GitHub Copilot), Claude Code, and Claude Desktop.
+
+For setup instructions and available tools, see the [VTEX Developer MCP](https://developers.vtex.com/docs/guides/vtex-developer-mcp) guide.
+
+## VTEX Skills
+
+VTEX Skills is a catalog of 42 AI agent skills for VTEX platform development, available in six export formats from a single source. Skills encode real platform constraints that LLMs don't know out of the box — things like Overrides API behavior, PPP endpoint requirements, BFF patterns, and MasterData limits.
+
+The catalog covers six tracks: Architecture, FastStore, Payment, VTEX IO, Marketplace, and Headless. Install the full set with:
+
+```sh
+npx skills add vtex/skills
+```
+
+For installation options and the full skill catalog, see the [VTEX Skills](https://developers.vtex.com/docs/guides/vtex-skills) guide.
+
+## How they work together
+
+The MCP and Skills serve different purposes and complement each other well. The MCP handles real-time lookups — your assistant can fetch the latest API spec or search the docs mid-task. Skills handle domain knowledge — your assistant already knows the right patterns before it starts writing code.
+
+Use both for the best experience. The MCP keeps your assistant current; Skills keep it correct.
+
+## Quick comparison
+
+| Tool | What it does | How to install | Supported platforms |
+|---|---|---|---|
+| [VTEX Developer MCP](https://developers.vtex.com/docs/guides/vtex-developer-mcp) | Gives AI assistants access to VTEX documentation and API references | `npx -y @vtex/developer-mcp` | Cursor, VS Code, Claude Code, Claude Desktop |
+| [VTEX Skills](https://developers.vtex.com/docs/guides/vtex-skills) | Encodes VTEX-specific patterns and constraints into AI agents | `npx skills add vtex/skills` | Cursor, Copilot, Claude, AGENTS.md, OpenCode, Kiro |
+
+## Next steps
+
+- [VTEX Developer MCP](https://developers.vtex.com/docs/guides/vtex-developer-mcp) — Set up the MCP server and explore available tools.
+- [VTEX Skills](https://developers.vtex.com/docs/guides/vtex-skills) — Install AI skills and browse the track catalog.
+- [Developer experience](https://developers.vtex.com/docs/guides/developer-experience) — Learn about other VTEX developer tools and resources.

--- a/docs/guides/AI-Assisted-Development/vtex-developer-mcp.md
+++ b/docs/guides/AI-Assisted-Development/vtex-developer-mcp.md
@@ -96,7 +96,7 @@ Or add a `.mcp.json` file at your project root:
 }
 ```
 
-4. Quit and reopen Claude Desktop.
+1. Quit and reopen Claude Desktop.
 
 ## Available tools
 
@@ -120,7 +120,7 @@ A few tips on how to combine them:
 You can ask your AI assistant things like:
 
 - "Search VTEX documentation for payment provider integration"
-- "Fetch the full guide at https://developers.vtex.com/docs/guides/payments-integration-payment-provider-protocol"
+- "Fetch the full guide at <https://developers.vtex.com/docs/guides/payments-integration-payment-provider-protocol>"
 - "Find documentation about the catalog API"
 - "Search for API endpoints related to order placement"
 - "Get the full specification for the Create Order endpoint"

--- a/docs/guides/AI-Assisted-Development/vtex-developer-mcp.md
+++ b/docs/guides/AI-Assisted-Development/vtex-developer-mcp.md
@@ -1,0 +1,147 @@
+---
+title: "VTEX Developer MCP"
+slug: "vtex-developer-mcp"
+hidden: false
+createdAt: "2026-04-09T19:00:00.000Z"
+updatedAt: "2026-04-09T19:00:00.000Z"
+excerpt: "Connect your AI coding assistant to VTEX documentation and API references using the Model Context Protocol (MCP)."
+seeAlso:
+ - "/docs/guides/ai-assisted-development-overview"
+ - "/docs/guides/vtex-skills"
+hidePaginationPrevious: false
+hidePaginationNext: false
+---
+
+`@vtex/developer-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI coding assistants direct access to VTEX documentation and API references. Your AI assistant can search documentation, retrieve full articles, and look up API endpoint specifications — all from within your editor. No API key or authentication required.
+
+## Before you begin
+
+Make sure you have the following:
+
+- **Node.js 18 or later** — check your version with `node --version`
+- **An MCP-compatible AI development tool** — Cursor, VS Code with GitHub Copilot, Claude Code, or Claude Desktop
+
+## Platform setup
+
+Choose your editor below and follow the setup steps.
+
+### Cursor
+
+Add the server to `.cursor/mcp.json` in your project root (or `~/.cursor/mcp.json` for a global config):
+
+```json
+{
+  "mcpServers": {
+    "vtex-developer": {
+      "command": "npx",
+      "args": ["-y", "@vtex/developer-mcp"]
+    }
+  }
+}
+```
+
+### VS Code / GitHub Copilot
+
+Add the server to `.vscode/mcp.json` in your project root:
+
+> VS Code uses `"servers"` as the top-level key, not `"mcpServers"`.
+
+```json
+{
+  "servers": {
+    "vtex-developer": {
+      "command": "npx",
+      "args": ["-y", "@vtex/developer-mcp"],
+      "type": "stdio"
+    }
+  }
+}
+```
+
+### Claude Code
+
+Run this command in your terminal:
+
+```bash
+claude mcp add vtex-developer -- npx -y @vtex/developer-mcp
+```
+
+Or add a `.mcp.json` file at your project root:
+
+```json
+{
+  "mcpServers": {
+    "vtex-developer": {
+      "command": "npx",
+      "args": ["-y", "@vtex/developer-mcp"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+1. Open Claude Desktop, then go to **Claude** menu → **Settings...** → **Developer** tab.
+2. Click **Edit Config** to open `claude_desktop_config.json`.
+3. Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "vtex-developer": {
+      "command": "npx",
+      "args": ["-y", "@vtex/developer-mcp"]
+    }
+  }
+}
+```
+
+4. Quit and reopen Claude Desktop.
+
+## Available tools
+
+Once connected, your AI assistant has access to four tools:
+
+| Tool | Description | Key parameters |
+|---|---|---|
+| `search_documentation` | Hybrid semantic + keyword search across VTEX Help Center and Developer Portal | `query` (required), `locale` (en, es, pt — required), `limit` (1–50), `format` |
+| `fetch_document` | Retrieve the full content of a VTEX documentation article by URL | `url` (required), `format` |
+| `search_endpoints` | Search VTEX API endpoints by query over OpenAPI definitions | `query` (required), `limit` (1–50), `method` (GET, POST, etc.), `format` |
+| `get_endpoint_details` | Get the full OpenAPI specification for a specific endpoint | `endpoint_id` (required), `format` |
+
+A few tips on how to combine them:
+
+- Use `search_documentation` to find relevant articles, then `fetch_document` to get the full content.
+- Use `search_endpoints` to find API endpoints, then `get_endpoint_details` for the complete OpenAPI specification.
+- All tools support a `format` parameter (`markdown`, `json`, `yaml`, `toml`) — defaults to `markdown`.
+
+## Usage examples
+
+You can ask your AI assistant things like:
+
+- "Search VTEX documentation for payment provider integration"
+- "Fetch the full guide at https://developers.vtex.com/docs/guides/payments-integration-payment-provider-protocol"
+- "Find documentation about the catalog API"
+- "Search for API endpoints related to order placement"
+- "Get the full specification for the Create Order endpoint"
+
+## Troubleshooting
+
+**Node.js not installed**
+The server requires Node.js 18 or later. Check your version with `node --version`. If it's missing or outdated, install it from [nodejs.org](https://nodejs.org).
+
+**`npx` not found**
+`npx` ships with Node.js. Reinstall Node.js to get it back.
+
+**Server not connecting**
+Check that you have internet access. If you're behind a corporate firewall, make sure outbound HTTPS traffic is allowed.
+
+**Server not appearing in your MCP client**
+Restart your editor. Claude Desktop requires a full quit and reopen, not just a window close.
+
+**VS Code: tools not appearing**
+Make sure you're using `"servers"` (not `"mcpServers"`) as the top-level key in `.vscode/mcp.json`.
+
+---
+
+For more details, see the [@vtex/developer-mcp](https://www.npmjs.com/package/@vtex/developer-mcp) npm package.

--- a/docs/guides/AI-Assisted-Development/vtex-skills.md
+++ b/docs/guides/AI-Assisted-Development/vtex-skills.md
@@ -1,0 +1,141 @@
+---
+title: "VTEX Skills"
+slug: "vtex-skills"
+hidden: false
+createdAt: "2026-04-09T19:00:00.000Z"
+updatedAt: "2026-04-09T19:00:00.000Z"
+excerpt: "Install AI agent skills that encode VTEX-specific patterns, constraints, and best practices into your AI coding assistant."
+seeAlso:
+ - "/docs/guides/ai-assisted-development-overview"
+ - "/docs/guides/vtex-developer-mcp"
+hidePaginationPrevious: false
+hidePaginationNext: false
+---
+
+VTEX Skills is a collection of 42 AI agent skills for VTEX platform development. One source, six export formats. Skills encode VTEX-specific patterns, constraints, and best practices into your AI coding assistant, giving it domain expertise that goes beyond generic LLM knowledge.
+
+## Why use VTEX Skills
+
+AI assistants don't know VTEX-specific patterns out of the box. The Overrides API, PPP endpoints, BFF requirements, and MasterData schema limits aren't in any LLM's training data at the depth you need. Skills fill that gap with real constraints, not generic advice.
+
+- **Platform-specific constraints**: PCI compliance via the Secure Proxy, idempotency requirements on payment endpoints, the 2.5s fulfillment simulation timeout, the 60-schema MasterData limit. These are the details that prevent costly mistakes in production.
+- **One source, six platforms**: Skills are authored once and exported automatically. No manual sync, no drift between tools.
+- **Built from official VTEX documentation**: Content comes from the same source your team already trusts.
+- **Works with your existing tools**: Cursor, GitHub Copilot, Claude, OpenCode, Kiro, and 38+ other agents are supported.
+- **No configuration required**: The `npx` installer detects your tools and places files in the right locations. Install once and your agent has the context it needs.
+- **Versioned and maintained**: Skills are updated when VTEX documentation changes, so your agent's knowledge stays current.
+
+## How it works
+
+Skills are plain text files your AI agent reads before generating code. When you install VTEX Skills, your agent gets context about:
+
+- Which APIs to call for a given use case and what parameters they expect
+- Platform constraints that aren't obvious from API docs alone (rate limits, schema caps, timeout windows)
+- Correct patterns for common tasks like setting up a FastStore override, implementing a PPP endpoint, or configuring a MasterData entity
+- Security requirements specific to VTEX, including PCI scope boundaries and Secure Proxy usage
+
+The skills CLI detects which AI tools you have installed and places files in the right locations automatically. You don't need to configure anything manually.
+
+### VTEX Skills vs. VTEX Developer MCP
+
+These two tools are complementary, not alternatives.
+
+The [VTEX Developer MCP](https://developers.vtex.com/docs/guides/vtex-developer-mcp) gives your AI assistant real-time access to VTEX documentation and API references. It's useful when your agent needs to look something up during a task.
+
+VTEX Skills encodes that knowledge as standing context. Your agent doesn't need to search for it. Skills are loaded once and stay active throughout your session, so your agent already knows the patterns before you ask your first question.
+
+Use both together for the best results: Skills for domain expertise, MCP for live documentation lookup.
+
+## Quick start
+
+The fastest way to get started is with `npx`. It detects your installed AI tools and places skill files in the right locations. If you prefer manual installation or need to target a specific platform, use the platform-specific commands below.
+
+### npx (Recommended)
+
+Works with Cursor, Claude Code, Codex, OpenCode, and 38+ agents. Auto-detects installed AI tools.
+
+```bash
+npx skills add vtex/skills
+```
+
+Use `--list` to preview available skills, or `--all` to install everything non-interactively. This uses the [open skills CLI](https://github.com/vercel-labs/skills).
+
+### AGENTS.md
+
+Works with Cursor, Copilot, Codex, Windsurf, Amp, Devin, and more:
+
+```bash
+curl -sL https://github.com/vtex/skills/releases/latest/download/agents-md.tar.gz | tar xz -C your-project/
+```
+
+### Cursor
+
+```bash
+mkdir -p your-project/.cursor/rules
+curl -sL https://github.com/vtex/skills/releases/latest/download/cursor-rules.tar.gz | tar xz -C your-project/.cursor/rules/
+```
+
+### GitHub Copilot
+
+```bash
+mkdir -p your-project/.github
+curl -sL https://github.com/vtex/skills/releases/latest/download/copilot-instructions.tar.gz | tar xz -C your-project/.github/
+```
+
+### Claude Projects
+
+Upload files from [`exports/claude/`](https://github.com/vtex/skills/tree/main/exports/claude) as project knowledge in your Claude Project settings.
+
+### OpenCode
+
+```bash
+curl -sL https://github.com/vtex/skills/releases/latest/download/opencode-skills.tar.gz | tar xz -C ~/.config/opencode/skills/
+```
+
+### Kiro
+
+```bash
+curl -sL https://github.com/vtex/skills/releases/latest/download/kiro-power.tar.gz | tar xz -C your-project/
+```
+
+## Tracks and skills
+
+Skills are organized into six tracks covering the main VTEX development surfaces. Each track groups related skills so your agent gets focused context for the work at hand. You can install all tracks at once or pick only the ones relevant to your project.
+
+| Track | Skills | Description |
+|---|---|---|
+| Well-Architected Commerce | 1 | Cross-cutting architecture guidance and solution design |
+| FastStore Implementation | 4 | Overrides, theming, SDK hooks, and data fetching for FastStore storefronts |
+| Payment Connector Development | 5 | Payment Provider Protocol endpoints, framework lifecycle, idempotency, async flows, and PCI compliance |
+| Custom VTEX IO Apps | 24 | Foundations, API exposure, frontend, data and config, security and operations for IO app development |
+| Marketplace Integration | 4 | SKU catalog sync, order hooks, fulfillment simulation, and rate limiting |
+| Headless Front-End Development | 4 | BFF architecture, Intelligent Search API, checkout proxy patterns, and caching strategy |
+
+The Custom VTEX IO Apps track is the largest, with 24 skills covering the full lifecycle of IO app development. If you're building a new IO app, install that track first.
+
+## Supported platforms
+
+Skills are available in six formats, one for each major AI development platform. All formats contain the same underlying content. The difference is how each platform discovers and loads the files.
+
+| Platform | Format | Auto-detection |
+|---|---|---|
+| AGENTS.md | Markdown | Yes (native in 7+ tools) |
+| Cursor | `.mdc` rules | Yes (glob + description) |
+| GitHub Copilot | Instructions | Yes (auto-loaded) |
+| Claude Projects | Knowledge files | Manual upload |
+| OpenCode | `SKILL.md` | Yes (auto-discovered) |
+| Kiro | `POWER.md` + steering | Yes (auto-discovered) |
+
+The `npx` installer handles placement automatically for all detected tools. For platforms not detected automatically (like Claude Projects), use the manual install commands above.
+
+## Keeping skills up to date
+
+Skills are versioned and released alongside VTEX documentation updates. To update to the latest version, re-run the install command for your platform. The `npx` approach always pulls the latest release.
+
+If you installed via `curl`, check the [releases page](https://github.com/vtex/skills/releases) for changelogs before updating.
+
+> **Tip**: Pin a specific version in CI environments to avoid unexpected behavior from skill updates. Use `npx skills add vtex/skills@<version>` or reference a tagged release URL in your `curl` commands.
+
+## Learn more
+
+For the full skill catalog, per-track details, and contributing guide, see the [VTEX Skills GitHub repository](https://github.com/vtex/skills).

--- a/docs/guides/AI-Assisted-Development/vtex-skills.md
+++ b/docs/guides/AI-Assisted-Development/vtex-skills.md
@@ -94,8 +94,11 @@ curl -sL https://github.com/vtex/skills/releases/latest/download/opencode-skills
 
 ### Kiro
 
+Clone the repository and copy the Kiro export files:
+
 ```bash
-curl -sL https://github.com/vtex/skills/releases/latest/download/kiro-power.tar.gz | tar xz -C your-project/
+git clone https://github.com/vtex/skills.git
+cp -r skills/exports/kiro/. your-project/
 ```
 
 ## Tracks and skills


### PR DESCRIPTION
## Summary

Adds a new **AI-Assisted Development** guides category with three articles documenting VTEX's AI-powered developer tools:

- **AI-Assisted Development overview** (`ai-assisted-development-overview.md`) — Introduction to the two tools and how they complement each other.
- **VTEX Developer MCP** (`vtex-developer-mcp.md`) — Setup instructions for Cursor, VS Code, Claude Code, and Claude Desktop. Documents all 4 MCP tools.
- **VTEX Skills** (`vtex-skills.md`) — Installation for 7 platforms. Overview of 42 skills across 6 tracks.

## Files added

- `docs/guides/AI-Assisted-Development/ai-assisted-development-overview.md`
- `docs/guides/AI-Assisted-Development/vtex-developer-mcp.md`
- `docs/guides/AI-Assisted-Development/vtex-skills.md`

## Notes

- `navigation.json` update is a separate follow-up (lives in the devportal app repo).
- Release note announcing these tools is in a separate PR.
- English only for v1.