### PR TITLE
[TEST] Add release notes for PLP 'Load more' fix

### DIFF
--- a/docs/release-notes/2026-05-11-plp-load-more-fix.md
+++ b/docs/release-notes/2026-05-11-plp-load-more-fix.md
@@ -1,0 +1,34 @@
+---
+title: "FastStore: PLP 'Load more' fix"
+slug: "faststore-plp-load-more-fix"
+excerpt: "Clicking 'Load more products' on PLPs now appends additional pages instead of replacing the current list."
+type: "bug-fix"
+publishedAt: "2026-05-11"
+---
+
+## What changed
+
+On Product Listing Pages (PLPs), clicking **Load more products** now appends additional pages (24, 36, ...) to the current list instead of replacing it. Filter and sort changes continue to reset the gallery to the first page as expected.
+
+## Why this matters
+
+This fix restores the expected infinite scroll behavior on PLPs. Without it, users would lose their browsing context every time the URL changed.
+
+## Behavior details
+
+- Deep-linking to `?page=N` continues to work as before.
+- Browser back/forward navigation continues to work as before.
+- Filter or sort changes still correctly reset the gallery to the first page.
+
+## Developer impact
+
+This is an internal fix in `@faststore/sdk` with no public API changes required. Code that relied on `resetInfiniteScroll` running on every URL change may observe fewer resets.
+
+## Action required
+
+No action required. The fix is included automatically when you update `@faststore/sdk`.
+
+## Reference
+
+- PR: [#3308](https://github.com/vtex/faststore/pull/3308)
+- Jira: [SFS-3162](https://vtex-dev.atlassian.net/browse/SFS-3162)


### PR DESCRIPTION
This release note details a fix for the 'Load more products' functionality on Product Listing Pages (PLPs), ensuring that additional pages are appended to the current list instead of replacing it. It also highlights the implications for deep-linking, navigation, and internal SDK behavior.

### Summary

Provide a concise description of the change introduced by this PR.
*Example: “Updates the Checkout overview to include new webhook behavior.”*

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [ ] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs` folder, except `docs/localization`.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.
