### PR TITLE
chore: add temp/ and .claude/settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 .DS_Store
 **/.DS_Store
 .vscode/settings.json
+temp/
+.claude/settings.json


### PR DESCRIPTION

- Added `temp/` directory to `.gitignore`
- Added `.claude/settings.json` to `.gitignore`

## Why

These are local development artifacts that should not be tracked in version control:
- `temp/` is a scratch directory for local work
- `.claude/settings.json` contains Claude Code editor settings specific to the local environment
