### PR TITLE
docs: add cross-reference and Mermaid config to B2B Buyer Portal docs

### DIFF
--- a/docs/guides/b2b/b2b-buyer-portal/b2b-buyer-portal-integration-overview.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-buyer-portal-integration-overview.md
@@ -3,7 +3,7 @@ title: "B2B Buyer Portal integration overview"
 slug: "b2b-buyer-portal-integration-overview"
 hidden: false
 createdAt: "2026-03-13T00:00:00.000Z"
-updatedAt: "2026-03-13T00:00:00.000Z"
+updatedAt: "2026-06-08T00:00:00.000Z"
 excerpt: "Explore the integration capabilities of B2B Buyer Portal, including contracts, organization management, payment cards, addresses, Budgets, Buying policies, Accounting fields, and Punchout."
 ---
 
@@ -38,6 +38,8 @@ B2B Buyer Portal integrations are built around the following core concepts:
 - [Organizational Units](https://help.vtex.com/en/docs/tutorials/organization-units) represent the hierarchical structure under that root, such as departments, divisions, or subsidiaries. They are the central entity for scoping many buyer portal features.
 - **Storefront users** are members of the buyer organization who interact with the store, each assigned specific roles and permissions.
 - **Storefront roles** control what actions each user can perform, from placing orders to managing budgets.
+
+> ℹ️ For how buyer organization data maps to Master Data entities and their relationships, see [B2B Buyer Portal Master Data architecture](https://developers.vtex.com/docs/guides/b2b-buyer-portal-master-data-architecture).
 
 ## Contracts
 

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-buyer-portal-integration-overview.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-buyer-portal-integration-overview.md
@@ -35,7 +35,7 @@ This guide provides an overview of the integration capabilities available in B2B
 B2B Buyer Portal integrations are built around the following core concepts:
 
 - **Contracts** sit at the **root** of the buyer organization. They define the commercial conditions that apply to the whole organization, such as product assortment, prices, and payment methods.
-- [Organizational Units](https://help.vtex.com/en/docs/tutorials/organization-units) represent the hierarchical structure under that root, such as departments, divisions, or subsidiaries. They are the central entity for scoping many buyer portal features.
+- [Organizational Units](https://help.vtex.com/docs/tutorials/organizational-units) represent the hierarchical structure under that root, such as departments, divisions, or subsidiaries. They are the central entity for scoping many buyer portal features.
 - **Storefront users** are members of the buyer organization who interact with the store, each assigned specific roles and permissions.
 - **Storefront roles** control what actions each user can perform, from placing orders to managing budgets.
 
@@ -87,7 +87,6 @@ The provisioning flow includes registering storefront credentials in VTEX ID, as
 | Create storefront users | Register users in VTEX ID with unique usernames and optional login emails. |
 | Assign users to units | Link storefront users to their respective organizational units. |
 | Assign storefront roles | Grant role-based permissions that control what each user can do. |
-
 
 The key APIs related to user provisioning are:
 
@@ -149,7 +148,7 @@ Shipping destinations, internal delivery points, and recipients support checkout
 
 A **location** is a specific delivery point within a site, such as a dock, department, or internal area. For example, freight may be consigned to the company's street address while the actual delivery is to **Dock 3456**. Locations are managed through the [Custom Fields API](https://developers.vtex.com/docs/api-reference/custom-fields-api). See [Custom Fields integration](https://developers.vtex.com/docs/guides/custom-fields-integration) to learn more.
 
-**Recipients** are the people who can be chosen as **order recipients**, who will receive the shipment. At checkout, the buyer selects the recipient for the order. That person may be different from the user placing the order. Recipient records are maintained at the **organization** level and can be **associated with addresses**, so choosing a shipping address can narrow which recipients are offered. Use the [B2B Recipients API](https://developers.vtex.com/docs/api-reference/b2b-recipients-api) to manage recipients in B2B scenarios.
+**Recipients** are the people who can be chosen as **order recipients**, who will receive the shipment. At checkout, the buyer selects the recipient for the order. That person may be different from the user placing the order. Recipient records are maintained at the **organization** level and can be **associated with addresses**, so choosing a shipping address can narrow which recipients are offered. Use the [B2B Addresses API](https://developers.vtex.com/docs/api-reference/b2b-addresses) to manage recipients in B2B scenarios.
 
 ## Budgets and allocations
 

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-buyer-portal-master-data-architecture.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-buyer-portal-master-data-architecture.md
@@ -39,6 +39,7 @@ The diagram shows logical references between entities. Edge labels are the field
 [`OrgUnit`](https://developers.vtex.com/docs/guides/b2b-buyer-portal-integration-overview#organizational-units-and-scopes) and storefront [`User`](https://developers.vtex.com/docs/guides/b2b-buyer-portal-integration-overview#user-provisioning) records are not Master Data entities. They appear here because several Master Data entities reference organizational unit IDs or VTEX user IDs.
 
 ```mermaid
+%%{init: {"flowchart": {"curve": "linear", "useMaxWidth": true}}}%%
 flowchart TB
     CL --> OrgUnit
     CL -->|"userId"| AD


### PR DESCRIPTION
Minor improvements to two B2B Buyer Portal articles: adds a cross-reference callout and fixes the Mermaid diagram configuration.

## Changes

- **Integration overview**: Added an info callout pointing readers to the Master Data architecture article for context on how buyer organization data maps to Master Data entities. Also updated the `updatedAt` frontmatter date.
- **Master Data architecture**: Added a Mermaid `init` directive to set `curve: linear` and `useMaxWidth: true`, improving diagram rendering consistency.
