### PR TITLE
Exclude PR Checklist and AI review sections from Jira descriptions.

### DIFF
--- a/.github/scripts/jira_helpers.sh
+++ b/.github/scripts/jira_helpers.sh
@@ -2,6 +2,16 @@
 # Source after setting LOC_JIRA_BASE_URL, LOC_JIRA_USER_EMAIL, LOC_JIRA_API_TOKEN,
 # LOC_JIRA_PROJECT_KEY, PR_NUMBER, GITHUB_REPOSITORY, PR_REF, PR_LABEL, and GH_TOKEN.
 
+# Drop PR template sections that should not appear in Jira descriptions.
+strip_pr_description_sections() {
+  awk '
+    /^#{1,6}[[:space:]]+Checklist([[:space:]]*|$)/ { skip=1; next }
+    /^#{1,6}[[:space:]]+AI review instructions([[:space:]]*|$)/ { skip=1; next }
+    /^#{1,6}[[:space:]]+/ { skip=0 }
+    !skip { print }
+  '
+}
+
 jira_post_search() {
   local jql="$1"
   local fields_csv="$2"

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -230,7 +230,7 @@ jobs:
           DAYS_TO_DUE=$((DAYS_TO_FOLLOWING_MONDAY + 4 + EXTRA_WEEKS * 7))
           JIRA_DUE_DATE=$(date -u -d "${TODAY} + ${DAYS_TO_DUE} days" +%Y-%m-%d)
 
-          PR_BODY=$(echo "$PR_BODY_RAW" | sed \
+          PR_BODY=$(echo "$PR_BODY_RAW" | strip_pr_description_sections | sed \
             -e 's/^#### /h4. /' \
             -e 's/^### /h3. /' \
             -e 's/^## /h2. /' \


### PR DESCRIPTION
### Summary

Small change to stop copying into the Jira LOC task some unneeded sections from the PR description.