### PR TITLE
EDU-18928 - Activity Flow: atualizar doc Flutter

### DIFF
--- a/docs/guides/Activity-Flow/installing-activity-flow-in-flutter-apps.md
+++ b/docs/guides/Activity-Flow/installing-activity-flow-in-flutter-apps.md
@@ -1,6 +1,7 @@
 ---
 title: "Installing Activity Flow in Flutter apps"
 slug: "installing-activity-flow-in-flutter-apps"
+excerpt: "Learn how to install the VTEX Activity Flow SDK in your Flutter app to track navigation, page views, deep links, ads, and customer interactions across Android and iOS."
 hidden: false
 createdAt: "2025-12-18T16:30:39.842Z"
 updatedAt: "2026-07-03T00:00:00.000Z"
@@ -495,7 +496,7 @@ class ButtonTemplate extends StatelessWidget {
 }
 ```
 
-The example demonstrates integrating Activity Flow into a Flutter app by importing the necessary package, initializing it with `initActivityFlow(accountName: appAccountName)`, and constructing a `MaterialApp` with named routes and a `PageViewObserver` to automatically capture page-view events.
+The example demonstrates how to integrate Activity Flow into a Flutter app by importing the necessary package, initializing it with `initActivityFlow(accountName: appAccountName)`, and constructing a `MaterialApp` with named routes and a `PageViewObserver` to automatically capture page-view events.
 
 It outlines a `MyHomePage` that incorporates an `AdBanner` that uses `addAdsListener` to pass ad metadata, such as product name, price, and ID. Additionally, it features navigation buttons sourced from a routes list.
 

--- a/docs/guides/Activity-Flow/installing-activity-flow-in-flutter-apps.md
+++ b/docs/guides/Activity-Flow/installing-activity-flow-in-flutter-apps.md
@@ -3,9 +3,12 @@ title: "Installing Activity Flow in Flutter apps"
 slug: "installing-activity-flow-in-flutter-apps"
 hidden: false
 createdAt: "2025-12-18T16:30:39.842Z"
+updatedAt: "2026-07-03T00:00:00.000Z"
+seeAlso:
+  - "/docs/guides/activity-flow"
 ---
 
-In this guide, you'll learn how to install and configure the [VTEX Activity Flow SDK](https://developers.vtex.com/docs/guides/activity-flow) in Flutter apps for Android and iOS. By following these steps, you'll be able to track user navigation, handle deep links, and collect ad events from your app.
+In this guide, you'll learn how to install and configure the [VTEX Activity Flow SDK](https://developers.vtex.com/docs/guides/activity-flow) in Flutter apps for Android and iOS. By following these steps, you'll be able to track user navigation, handle deep links, and collect ad events and customer interaction events (clicks, views, and impressions) in your app.
 
 ## Before you begin
 
@@ -25,7 +28,7 @@ This installs the SDK and updates your `pubspec.yaml` file with the `activity_fl
 
 In your app's main file, import the Activity Flow package as follows:
 
-```javascript
+```dart
 import 'package:activity_flow/activity_flow.dart';
 ```
 
@@ -33,19 +36,17 @@ import 'package:activity_flow/activity_flow.dart';
 
 Set the account name to create an instance of the main package class:
 
-```java
+```dart
 void main() {
-runApp(const MyApp());
+  runApp(const MyApp());
 }
 
 class App extends StatelessWidget {
-
   Widget build(BuildContext context) {
-
-// Call activity flow here
+    // Call activity flow here
     initActivityFlow(accountName: appAccountName);
-...
-
+    ...
+  }
 }
 ```
 
@@ -55,7 +56,7 @@ class App extends StatelessWidget {
 
 To automatically track user navigation between app pages, add the `PageViewObserver` to the `navigatorObservers` list in your app:
 
-```java
+```dart
 MyApp(
    // Add the PageViewObserver to the navigatorObservers list.
    navigatorObservers: [PageViewObserver()],
@@ -70,11 +71,11 @@ This setup enables automatic screen view tracking for standard route navigation.
 
 ### Tracking page views manually (for custom navigation)
 
-For navigation widgets like `BottomNavigationBar` or `TabBar`, which do not trigger route changes, use the `trackPageView` function to manually track screen views.
+For navigation widgets such as `BottomNavigationBar` or `TabBar` that don't trigger route changes, use the `screenViewChange` function to manually track screen views.
 
 For example, using the `onTap` callback within a `BottomNavigationBar` widget allows for capturing a new route each time the user taps on a different tab:
 
-```java
+```dart
 BottomNavigationBar(
    items: items,
    currentIndex: _selectedIndex,
@@ -83,8 +84,8 @@ BottomNavigationBar(
       _onItemTapped(index);
       final label = items[index].label ?? 'Tab-$index';
 
-      // Manually calling the `trackPageView` with the label
-      trackPageView(label);
+      // Manually calling the `screenViewChange` with the label
+      screenViewChange(label);
    },
 )
 ```
@@ -97,7 +98,7 @@ The Activity Flow SDK automatically captures deep link query parameters and incl
 
 Add intent filters to `AndroidManifest.xml` for each route that can be accessed via deep link:
 
-``` android/app/src/main/AndroidManifest.xml
+```xml android/app/src/main/AndroidManifest.xml
 <intent-filter>
   <action android:name="android.intent.action.VIEW" />
   <category android:name="android.intent.category.DEFAULT" />
@@ -105,7 +106,8 @@ Add intent filters to `AndroidManifest.xml` for each route that can be accessed 
   <data
     android:scheme="https"
     android:host="example.com"
-    android:pathPrefix="{APP_ROUTE}" />
+    android:pathPrefix="{APP_ROUTE}"
+  />
 </intent-filter>
 
 <intent-filter>
@@ -124,119 +126,119 @@ Configure both `Info.plist` and the app delegate to handle deep links.
 
 1. Register a custom URL scheme in `Info.plist`:
 
-``` ios/{YourApp}/Info.plist
-<key>CFBundleURLTypes</key>
-<array>
-  <dict>
-    <key>CFBundleURLSchemes</key>
+    ```xml ios/{YourApp}/Info.plist
+    <key>CFBundleURLTypes</key>
     <array>
-      <string>{YOUR_BUNDLE_URL_SCHEME}</string>
+      <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>{YOUR_BUNDLE_URL_SCHEME}</string>
+        </array>
+        <key>CFBundleURLName</key>
+        <string>{YOUR_BUNDLE_URL_NAME}</string>
+      </dict>
     </array>
-    <key>CFBundleURLName</key>
-    <string>{YOUR_BUNDLE_URL_NAME}</string>
-  </dict>
-</array>
-```
+    ```
 
 2. Handle incoming URLs in `AppDelegate.swift` (or `AppDelegate.mm`) for both cold and warm starts:
 
-```typescript
-import Flutter
-import UIKit
-import activity_flow
+    ```swift
+    import Flutter
+    import UIKit
+    import activity_flow
 
-@main
-@objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
+    @main
+    @objc class AppDelegate: FlutterAppDelegate {
+      override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+      ) -> Bool {
+        GeneratedPluginRegistrant.register(with: self)
 
-    // Capture initial URL if app was launched with a deep link (cold start)
-    if let initialURL = launchOptions?[UIApplication.LaunchOptionsKey.url] as? URL {
-      DeepLinkManager.shared.handle(url: initialURL)
-    }
+        // Capture initial URL if app was launched with a deep link (cold start)
+        if let initialURL = launchOptions?[UIApplication.LaunchOptionsKey.url] as? URL {
+          DeepLinkManager.shared.handle(url: initialURL)
+        }
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+      }
 
-  // Handles incoming URLs from Custom URL Schemes (e.g., myapp://path)
-  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    DeepLinkManager.shared.handle(url: url)
-    return super.application(app, open: url, options: options)
-  }
-
-  // Handles incoming URLs from Universal Links
-  override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-    // Check if the activity is a web browsing activity (Universal Link)
-    if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-      if let url = userActivity.webpageURL {
+      // Handles incoming URLs from Custom URL Schemes (e.g., myapp://path)
+      override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         DeepLinkManager.shared.handle(url: url)
+        return super.application(app, open: url, options: options)
+      }
+
+      // Handles incoming URLs from Universal Links
+      override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        // Check if the activity is a web browsing activity (Universal Link)
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+          if let url = userActivity.webpageURL {
+            DeepLinkManager.shared.handle(url: url)
+          }
+        }
+        return super.application(application, continue: userActivity, restorationHandler: restorationHandler)
       }
     }
-        return super.application(application, continue: userActivity, restorationHandler: restorationHandler)
-  }
-}
-```
+    ```
 
 3. Configure `SceneDelegate`
 
 If your project uses a `SceneDelegate`, also forward deep links there:
 
-```typescript ios/Runner/SceneDelegate.swift
-import UIKit
-import Flutter
-import activity_flow
+    ```swift ios/Runner/SceneDelegate.swift
+    import UIKit
+    import Flutter
+    import activity_flow
 
-class SceneDelegate: FlutterSceneDelegate {
-  override func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-    // Capture deep links on cold start
-    var hasDeepLink = false
+    class SceneDelegate: FlutterSceneDelegate {
+        override func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+            // Capture deep links on cold start
+            var hasDeepLink = false
 
-    if let userActivity = connectionOptions.userActivities.first(where: { $0.activityType == NSUserActivityTypeBrowsingWeb }) {
-    if let url = userActivity.webpageURL {
-      DeepLinkManager.shared.handle(url: url)
-      hasDeepLink = true
-      }
-    } else if let url = connectionOptions.urlContexts.first?.url {
-      DeepLinkManager.shared.handle(url: url)
-      hasDeepLink = true
+            if let userActivity = connectionOptions.userActivities.first(where: { $0.activityType == NSUserActivityTypeBrowsingWeb }) {
+                if let url = userActivity.webpageURL {
+                    DeepLinkManager.shared.handle(url: url)
+                    hasDeepLink = true
+                }
+            } else if let url = connectionOptions.urlContexts.first?.url {
+                DeepLinkManager.shared.handle(url: url)
+                hasDeepLink = true
+            }
+
+            // Call super with empty options if a deep link was handled
+            if hasDeepLink {
+                super.scene(scene, willConnectTo: session, options: UIScene.ConnectionOptions())
+            } else {
+                super.scene(scene, willConnectTo: session, options: connectionOptions)
+            }
+        }
+
+        override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+            if let url = URLContexts.first?.url {
+                DeepLinkManager.shared.handle(url: url)
+            }
+        }
+
+        override func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+            if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+                if let url = userActivity.webpageURL {
+                    DeepLinkManager.shared.handle(url: url)
+                }
+            }
+        }
     }
+    ```
 
-    // Call super with empty options if a deep link was handled
-    if hasDeepLink {
-      super.scene(scene, willConnectTo: session, options: UIScene.ConnectionOptions())
-    } else {
-      super.scene(scene, willConnectTo: session, options: connectionOptions)
-    }
-  }
-
-  override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    if let url = URLContexts.first?.url {
-      DeepLinkManager.shared.handle(url: url)
-    }
-  }
-
-  override func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-    if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-      if let url = userActivity.webpageURL {
-        DeepLinkManager.shared.handle(url: url)
-      }
-    }
-  }
-}
-```
-
-### (Optional) Tracking ad events
+### Tracking ad events
 
 >ℹ️ Ads tracking is available only for accounts using [VTEX Ads](https://developers.vtex.com/docs/guides/vtex-ads). If you're interested in this feature, open a ticket with [VTEX Support](https://support.vtex.com/hc/en-us).
 
 When you apply the listener to a widget, the SDK automatically tracks three events:
 
-- **Impression:** When the widget is first built and rendered.
-- **View:** When at least 50% of the widget is visible on screen for at least 1 continuous second.
-- **Click:** When the user taps the widget.
+- **Impressions:** When the widget is first built and rendered.
+- **Views:** When at least 50% of the widget is visible on screen for at least 1 continuous second.
+- **Clicks:** When the user taps the widget.
 
 To start tracking your ad events, follow these steps:
 
@@ -244,16 +246,16 @@ To start tracking your ad events, follow these steps:
 
 To enable tracking, call the `addAdsListener` extension method on any Flutter widget that represents an ad:
 
-```java
-yourAdWidget.addAdsListener({Map<String, String> adMetadata);
-```
+    ```dart
+    yourAdWidget.addAdsListener(Map<String, String> adMetadata);
+    ```
 
-- `yourAdWidget`: The ad widget you want to monitor.
-- `adMetadata`: A map containing specific details about the ad, which will be sent to your analytics service upon a click.
+    - `yourAdWidget`: The ad widget you want to monitor.
+    - `adMetadata`: A map containing specific details about the ad, which will be sent to your analytics service upon a click.
 
-The following example initializes the Activity Flow to track page views automatically and demonstrates manual tracking for tab changes:
+The following example initializes the Activity Flow to track page views automatically and demonstrates ad tracking:
 
-```
+```dart
 import 'package:activity_flow/activity_flow.dart';
 import 'package:flutter/material.dart';
 
@@ -294,6 +296,7 @@ class HomeScreen extends StatelessWidget {
               'campaignName': 'Summer Sale 2024',
             }),
           ),
+
           // More content
           const ProductTile(name: 'Product C'),
         ],
@@ -303,9 +306,75 @@ class HomeScreen extends StatelessWidget {
 }
 ```
 
-This Flutter screen is constructed as a `StatelessWidget` that lists products and displays an ad banner. The banner's Container is wrapped with Activity Flow's `addAdsListener`, which attaches an ad-event listener and sends the provided metadata map with each event.
+This Flutter screen is constructed as a `StatelessWidget` that lists products and displays an ad banner. The banner's `Container` is wrapped with Activity Flow's `addAdsListener`, which attaches an ad-event listener and sends the provided metadata map with each event.
 
 This instrumentation enables the automatic tracking of impressions, viewability, and clicks, allowing for comprehensive analytics tied to `adId`, `creativeId`, `position`, and `campaignName`.
+
+### Tracking customer interaction events
+
+Beyond page views and ad events, Activity Flow provides individual extension methods for tracking click, view, and impression events on any widget. These methods can be used independently or combined on the same widget.
+
+All methods require `elementSource`, a string that identifies the tracked element. This field is sent as a top-level property in the event payload, separate from the other attributes.
+
+#### Click event
+
+Use `addClickListener` on any widget to capture tap interactions. A click event is fired when the user taps (not drags) on the element. Pass any custom attributes you want to associate with the interaction.
+
+>ℹ️ You must include the `elementSource` key in the method's metadata map.
+
+```dart
+ElevatedButton(
+  onPressed: () => Navigator.pushNamed(context, '/checkout'),
+  child: const Text('Buy Now'),
+).addClickListener({
+  'elementSource': 'buy-now-button',
+  'productId': product.id,
+});
+```
+
+#### View event
+
+Use `addViewListener` to fire a view event when the widget has been at least 50% visible on screen for at least 1 second (IAB standard). The event fires once per app session — it does not re-fire if the widget scrolls off-screen and back, or if the user navigates away and returns.
+
+>ℹ️ You must include the `elementSource` key in the method's metadata map.
+
+```dart
+ProductCard(product: product).addViewListener({
+  'elementSource': 'product-card',
+  'productId': product.id,
+});
+```
+
+#### Impression events
+
+Use the `addImpressionListener` method to trigger an impression event immediately upon the widget being built and rendered within the application's widget tree.
+
+>ℹ️ You must include the `elementSource` key in the method's metadata map.
+
+```dart
+ProductCard(product: product).addImpressionListener({
+  'elementSource': 'product-card',
+  'productId': product.id,
+});
+```
+
+#### Combining multiple listeners
+
+Combine the listeners on a single widget to track the full interaction funnel: whether the element was rendered (impression), actually seen by the user (view), and clicked (click).
+
+The example below chains the impression and view listeners on a single widget to capture both event types simultaneously:
+
+```dart
+ProductCard(product: product)
+  .addImpressionListener({
+    'elementSource': 'product-card',
+    'productId': product.id,
+  })
+  .addViewListener({
+    'elementSource': 'product-card',
+    'productId': product.id,
+  });
+```
 
 ## Flutter automated tests
 
@@ -317,14 +386,14 @@ The `--dart-define` flag allows you to pass compile-time key=value pairs into yo
 2. In a code editor, open your project.
 3. In the code editor settings, search for `dart.flutterTestAdditionalArgs`.
 4. Add to it the value `--dart-define=ACTIVITY_FLOW_TEST_ENV=true`.
-5. Open the `settings.json` file of your project.
-6. Add the following: `"dart.flutterTestAdditionalArgs": ["--dart-define=ACTIVITY_FLOW_TEST_ENV=true"]`
+
+    >ℹ️ Alternatively, open the `settings.json` file of your project and add `"dart.flutterTestAdditionalArgs": ["--dart-define=ACTIVITY_FLOW_TEST_ENV=true"]`.
 
 ## Use case example
 
 Below is an example that contains an app with some pages and navigation through them:
 
-```java
+```dart
 import 'package:activity_flow/activity_flow.dart';
 import 'package:flutter/material.dart';
 import 'package:example/screens/favorite.dart';
@@ -332,96 +401,102 @@ import 'package:example/screens/products.dart';
 import 'package:example/screens/profile.dart';
 
 void main() {
-   runApp(const ExampleApp());
+  runApp(const ExampleApp());
 }
+
 /// A MaterialApp with a custom theme and routes.
+///
 /// The routes are defined in the [routes] property.
 /// The theme is defined in the [theme] property.
 class ExampleApp extends StatelessWidget {
-   const ExampleApp({super.key});
+  const ExampleApp({super.key});
 
-   @override
-   Widget build(BuildContext context) {
-      initActivityFlow(accountName: appAccountName);
+  @override
+  Widget build(BuildContext context) {
+    initActivityFlow(accountName: appAccountName);
 
-      return MaterialApp(
-         title: 'Example App',
-         theme: ThemeData(
-           colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-           useMaterial3: true,
-         ),
-         routes: {
-           '/': (context) => const MyHomePage(),
-           '/products': (context) => const ProductsScreen(),
-           '/profile': (context) => const ProfileScreen(),
-           '/favorites': (context) => const FavoriteScreen(),
-         },
-         initialRoute: '/',
-         navigatorObservers: [PageViewObserver()],
+    return MaterialApp(
+      title: 'Example App',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      routes: {
+        '/': (context) => const MyHomePage(),
+        '/products': (context) => const ProductsScreen(),
+        '/profile': (context) => const ProfileScreen(),
+        '/favorites': (context) => const FavoriteScreen(),
+      },
+      initialRoute: '/',
+      navigatorObservers: [PageViewObserver()],
+    );
+  }
+}
 
 /// A home screen with buttons to navigate to other screens.
 class MyHomePage extends StatelessWidget {
-   const MyHomePage({super.key});
+  const MyHomePage({super.key});
 
-   final List<Map> _routes = const [
-      {
-        'name': 'Products',
-        'route': '/products',
-      },
-      {
-        'name': 'Profile',
-        'route': '/profile',
-      }
-    ];
+  final List<Map> _routes = const [
+    {
+      'name': 'Products',
+      'route': '/products',
+    },
+    {
+      'name': 'Profile',
+      'route': '/profile',
+    }
+  ];
 
-   @override
-   Widget build(BuildContext context) {
-      return Scaffold(
-        appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-          title: const Text('Home Screen'),
-        ),
-        body: Center(
-          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-            const AdBanner().addAdsListener({
-              'productName': 'Sneakers',
-              'productPrice': '59.99',
-              'adID': '1123',
-            }),
-            ..._routes.map((route) => ButtonTemplate(
-                  title: route['name'],
-                  route: route['route'],
-               )),
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: const Text('Home Screen'),
+      ),
+      body: Center(
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          const AdBanner().addAdsListener({
+            'productName': 'Sneakers',
+            'productPrice': '59.99',
+            'adID': '1123',
+          }),
+          ..._routes.map((route) => ButtonTemplate(
+                title: route['name'],
+                route: route['route'],
+              )),
         ])),
-      );
-   }
+    );
+  }
 }
 
 /// A template for creating buttons.
+///
 /// Receives a [title], [icon], and [route] to navigate to.
 /// Returns an [ElevatedButton.icon] with the given parameters.
 class ButtonTemplate extends StatelessWidget {
-   const ButtonTemplate({
-      super.key,
-      required this.title,
-      required this.route,
-   });
+  const ButtonTemplate({
+    super.key,
+    required this.title,
+    required this.route,
+  });
 
-   final String title;
-   final String route;
+  final String title;
+  final String route;
 
-   @override
-   Widget build(BuildContext context) {
-      return ElevatedButton(
-        onPressed: () => Navigator.pushNamed(context, route),
-        child: Text(title),
-      );
-   }
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () => Navigator.pushNamed(context, route),
+      child: Text(title),
+    );
+  }
 }
 ```
 
-The example demonstrates the integration of Activity Flow into a Flutter app by importing the necessary package, initializing it with `initActivityFlow(accountName: appAccountName)`, and constructing a `MaterialApp` with named routes and a `PageViewObserver` to automatically capture page-view events.
+The example demonstrates integrating Activity Flow into a Flutter app by importing the necessary package, initializing it with `initActivityFlow(accountName: appAccountName)`, and constructing a `MaterialApp` with named routes and a `PageViewObserver` to automatically capture page-view events.
 
-It outlines a `MyHomePage` that incorporates an `AdBanner`, which uses `addAdsListener` to pass ad metadata such as product name, price, and ID. Additionally, it features navigation buttons sourced from a routes list.
+It outlines a `MyHomePage` that incorporates an `AdBanner` that uses `addAdsListener` to pass ad metadata, such as product name, price, and ID. Additionally, it features navigation buttons sourced from a routes list.
 
 The reusable `ButtonTemplate` facilitates navigation through `Navigator.pushNamed`, showcasing a standard configuration for automatic screen tracking, as well as ad impression and click tracking, in a Flutter application.


### PR DESCRIPTION
### Summary

[EDU-18928](https://vtex-dev.atlassian.net/browse/EDU-18928)

Preview:
First click [https://developers.vtex.com/api/preview?branch=EDU-18928-af-flutter-apps](https://developers.vtex.com/api/preview?branch=EDU-18928-af-flutter-apps)
Then click h[ttps://developers.vtex.com/docs/guides/installing-activity-flow-in-flutter-apps](https://developers.vtex.com/docs/guides/installing-activity-flow-in-flutter-apps)

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [X] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs` folder, except `docs/localization`.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.


[EDU-18928]: https://vtex-dev.atlassian.net/browse/EDU-18928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ