### PR TITLE
Add rename-aware partial Crowdin uploads

### DIFF
--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -4,7 +4,9 @@ Upload PR-touched markdown files to Crowdin and update Jira descriptions
 with Crowdin metadata (word count, editor links).
 
 Developer Portal uses a single Crowdin project with en-us source files
-reviewed in the same language (no PT/ES translation pipeline).
+reviewed in the same language (no PT/ES translation pipeline). Partial
+uploads use rename-aware git diffs; numstat rename paths are normalized
+in Python before processing.
 
 Commands:
   crowdin_sync.py              Upload touched files to Crowdin
@@ -31,6 +33,11 @@ CROWDIN_API_BASE_DEFAULT = "https://api.crowdin.com/api/v2"
 CROWDIN_WEB_BASE_DEFAULT = "https://crowdin.com"
 
 DOCS_SOURCE_PATH_PREFIX = "docs/"
+
+RENAME_PATH_PATTERN = re.compile(r"\{[^ ]+ => ([^}]+)\}")
+RENAME_STATUS_PATTERN = re.compile(r"^R\d+\t(.+)\t(.+)$")
+
+_rename_map: dict[str, str] = {}
 
 
 def env(name: str, default: str = "") -> str:
@@ -250,20 +257,120 @@ def is_eligible_path(relative_path: str) -> bool:
     return path.startswith(DOCS_SOURCE_PATH_PREFIX)
 
 
+def normalize_changed_path(path: str) -> str:
+    """Resolve git numstat rename syntax (dir/{old => new}) to the new path."""
+    normalized = path.replace("\\", "/").strip()
+    if "{" not in normalized or "=>" not in normalized:
+        return normalized
+
+    parent, _, name = normalized.rpartition("/")
+    if RENAME_PATH_PATTERN.search(name):
+        new_name = RENAME_PATH_PATTERN.sub(r"\1", name)
+        return f"{parent}/{new_name}" if parent else new_name
+    return RENAME_PATH_PATTERN.sub(r"\1", normalized)
+
+
 def changed_files() -> list[str]:
     raw = env("CHANGED_FILES")
     if not raw:
         return []
-    return [
-        line.strip()
-        for line in raw.splitlines()
-        if line.strip().endswith((".md", ".mdx")) and is_eligible_path(line.strip())
-    ]
+    seen: set[str] = set()
+    files: list[str] = []
+    for line in raw.splitlines():
+        path = normalize_changed_path(line.strip())
+        if (
+            path
+            and path.endswith((".md", ".mdx"))
+            and is_eligible_path(path)
+            and path not in seen
+        ):
+            seen.add(path)
+            files.append(path)
+    return files
+
+
+def build_rename_map(base_sha: str, head_sha: str) -> dict[str, str]:
+    rename_map: dict[str, str] = {}
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-status",
+            "-M",
+            f"{base_sha}...{head_sha}",
+            "--",
+            DOCS_SOURCE_PATH_PREFIX,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode in (0, 1):
+        for line in result.stdout.splitlines():
+            match = RENAME_STATUS_PATTERN.match(line)
+            if match:
+                rename_map[match.group(2)] = match.group(1)
+    return rename_map
+
+
+def diff_scope_for_path(relative_path: str, rename_source: str | None) -> str:
+    path = relative_path.replace("\\", "/")
+    if rename_source:
+        old = rename_source.replace("\\", "/")
+        old_parts = Path(old).parts
+        new_parts = Path(path).parts
+        common = [
+            left
+            for left, right in zip(old_parts, new_parts, strict=False)
+            if left == right
+        ]
+        if common:
+            return "/".join(common)
+        return DOCS_SOURCE_PATH_PREFIX.rstrip("/")
+    parent = str(Path(path).parent)
+    return parent if parent != "." else path
+
+
+def extract_file_diff(full_diff: str, relative_path: str) -> str:
+    target = relative_path.replace("\\", "/")
+    chunks: list[str] = []
+    current: list[str] = []
+    matches = False
+
+    for line in full_diff.splitlines(keepends=True):
+        if line.startswith("diff --git"):
+            if matches and current:
+                chunks.append("".join(current))
+            current = [line]
+            matches = False
+        else:
+            current.append(line)
+
+        stripped = line.rstrip("\n")
+        if stripped.startswith("+++ b/") and stripped[6:] == target:
+            matches = True
+        elif stripped.startswith("rename to ") and stripped[len("rename to ") :] == target:
+            matches = True
+
+    if matches and current:
+        chunks.append("".join(current))
+
+    return "".join(chunks)
 
 
 def git_diff(base_sha: str, head_sha: str, relative_path: str) -> str:
+    rename_source = _rename_map.get(relative_path.replace("\\", "/"))
+    scope = diff_scope_for_path(relative_path, rename_source)
     result = subprocess.run(
-        ["git", "diff", "-U0", f"{base_sha}...{head_sha}", "--", relative_path],
+        [
+            "git",
+            "diff",
+            "-U0",
+            "-M",
+            f"{base_sha}...{head_sha}",
+            "--",
+            scope,
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -273,7 +380,31 @@ def git_diff(base_sha: str, head_sha: str, relative_path: str) -> str:
             f"git diff failed for {relative_path}: "
             f"{result.stderr.strip() or result.stdout.strip()}"
         )
-    return result.stdout
+
+    extracted = extract_file_diff(result.stdout, relative_path)
+    if extracted.strip():
+        return extracted
+
+    fallback = subprocess.run(
+        [
+            "git",
+            "diff",
+            "-U0",
+            "-M",
+            f"{base_sha}...{head_sha}",
+            "--",
+            relative_path,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if fallback.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git diff failed for {relative_path}: "
+            f"{fallback.stderr.strip() or result.stdout.strip()}"
+        )
+    return fallback.stdout
 
 
 def parse_added_lines(diff_text: str) -> list[tuple[int, str]]:
@@ -313,6 +444,10 @@ def group_consecutive_blocks(additions: list[tuple[int, str]]) -> list[list[str]
 
 
 def is_new_file(diff_text: str) -> bool:
+    if not diff_text.strip():
+        return False
+    if "rename from" in diff_text or "similarity index" in diff_text:
+        return False
     return "new file mode" in diff_text
 
 
@@ -522,8 +657,11 @@ def upload_files_to_crowdin(
     head_sha: str,
     task_key: str,
 ) -> tuple[int, list[str], list[dict]]:
+    global _rename_map
     if not files:
         return 0, [], []
+
+    _rename_map = build_rename_map(base_sha, head_sha)
 
     project_id = require_project_id()
     project_data = fetch_project_data(project_id)

--- a/.github/scripts/jira_helpers.sh
+++ b/.github/scripts/jira_helpers.sh
@@ -2,6 +2,27 @@
 # Source after setting LOC_JIRA_BASE_URL, LOC_JIRA_USER_EMAIL, LOC_JIRA_API_TOKEN,
 # LOC_JIRA_PROJECT_KEY, PR_NUMBER, GITHUB_REPOSITORY, PR_REF, PR_LABEL, and GH_TOKEN.
 
+# Post a plain-text comment on a Jira issue. Returns 0 on HTTP 201.
+jira_post_comment() {
+  local issue_key="$1"
+  local body="$2"
+  local payload http_code
+
+  payload=$(jq -n --arg body "$body" '{body: $body}')
+  http_code=$(curl -s -o jira-comment-response.json -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
+    -d "$payload" \
+    "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${issue_key}/comment")
+
+  if [ "$http_code" -ne 201 ]; then
+    echo "Failed to post Jira comment on ${issue_key} (HTTP ${http_code})" >&2
+    cat jira-comment-response.json >&2
+    return 1
+  fi
+}
+
 jira_user_search() {
   local query="$1"
   local max_results="${2:-10}"
@@ -78,6 +99,7 @@ resolve_jira_reporter_from_github() {
 
   echo "Could not resolve Jira reporter for GitHub user ${github_login}; using API token user" >&2
   return 1
+}
 
 # Drop PR template sections that should not appear in Jira descriptions.
 strip_pr_description_sections() {

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -96,7 +96,7 @@ jobs:
           # Three-dot diff matches the GitHub PR "Files changed" tab (branch-only changes).
           DIFF_RANGE="${BASE_SHA}...${HEAD_SHA}"
 
-          INSERTIONS=$(git diff --numstat \
+          INSERTIONS=$(git diff --numstat -M \
             "$DIFF_RANGE" \
             -- docs/ \
             | awk '{sum += $1} END {print sum+0}')
@@ -107,7 +107,7 @@ jobs:
             echo "has_additions=false" >> $GITHUB_OUTPUT
           fi
 
-          CHANGED_FILES=$(git diff --numstat \
+          CHANGED_FILES=$(git diff --numstat -M \
             "$DIFF_RANGE" \
             -- docs/ \
             | awk '$1 > 0 {print $3}' \
@@ -174,28 +174,9 @@ jobs:
             "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${EXISTING_KEY}?fields=assignee" \
             | jq -r '.fields.assignee.displayName // "Assignee"')
 
-          COMMENT_PAYLOAD=$(jq -n \
-            --arg assignee "$ASSIGNEE" \
-            '{
-              body: (
-                $assignee + ", THE TASK WAS UPDATED IN GITHUB!\n" +
-                "But since it is already in production, it was not automatically updated here. " +
-                "Please check if any changes are needed."
-              )
-            }')
-
-          COMMENT_RESPONSE=$(curl -s -o production-lock-comment-response.json -w "%{http_code}" \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
-            -d "$COMMENT_PAYLOAD" \
-            "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${EXISTING_KEY}/comment")
-
-          if [ "$COMMENT_RESPONSE" -ne 201 ]; then
-            echo "Failed to post production lock comment on ${EXISTING_KEY} (HTTP ${COMMENT_RESPONSE})" >&2
-            cat production-lock-comment-response.json >&2
-            exit 1
-          fi
+          COMMENT_BODY="${ASSIGNEE}, THE TASK WAS UPDATED IN GITHUB!
+But since it is already in production, it was not automatically updated here. Please check if any changes are needed."
+          jira_post_comment "$EXISTING_KEY" "$COMMENT_BODY"
 
           echo "Production lock active for ${EXISTING_KEY} (Prepare file due: ${PREPARE_DUE}, today: ${TODAY})"
           echo "Posted production lock comment on ${EXISTING_KEY}"


### PR DESCRIPTION
## Summary
- Detect file renames when deciding partial vs full Crowdin uploads (cached name-status map + parent-scoped git diffs)
- Normalize numstat rename paths in `crowdin_sync.py` and pass `-M` to workflow diffs
- Add shared `jira_post_comment` helper for production-lock comments; fix missing brace on `resolve_jira_reporter_from_github`

## Test plan
- [ ] Label a PR with a renamed doc and ≤5 edit blocks → partial upload
- [ ] Label a PR with a new doc → full upload
- [ ] Confirm production-lock path still posts a Jira comment when Prepare file is due