### PR TITLE
Fix localization workflow YAML syntax

### DIFF
--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -174,8 +174,7 @@ jobs:
             "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${EXISTING_KEY}?fields=assignee" \
             | jq -r '.fields.assignee.displayName // "Assignee"')
 
-          COMMENT_BODY="${ASSIGNEE}, THE TASK WAS UPDATED IN GITHUB!
-But since it is already in production, it was not automatically updated here. Please check if any changes are needed."
+          COMMENT_BODY=$(printf '%s, THE TASK WAS UPDATED IN GITHUB!\nBut since it is already in production, it was not automatically updated here. Please check if any changes are needed.' "$ASSIGNEE")
           jira_post_comment "$EXISTING_KEY" "$COMMENT_BODY"
 
           echo "Production lock active for ${EXISTING_KEY} (Prepare file due: ${PREPARE_DUE}, today: ${TODAY})"


### PR DESCRIPTION
## Summary
- Fix invalid YAML in the production lock step caused by an unindented multi-line `COMMENT_BODY` assignment inside the `run: |` block
- Use `printf` with `\n` for the Jira comment body instead

## Test plan
- [ ] GitHub Actions workflow file validates without YAML syntax errors
- [ ] Production lock step still posts the same Jira comment when Prepare file is due