### PR TITLE
fix: checkout merge ref in localization workflow

### DIFF
--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -84,7 +84,8 @@ jobs:
         if: steps.eligibility.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          # Merge ref so workflow scripts come from main on branches behind main.
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Check for content additions


### PR DESCRIPTION
## Purpose
Fix `jira_helpers.sh` syntax errors on loc PRs whose branches are behind `main`.

## Summary
- Checkout `github.sha` (merge ref) instead of `pull_request.head.sha` so workflow scripts come from `main`
- Content diffs still use `pull_request.head.sha` vs base
- `jira_helpers.sh` closing brace fix is already on `main` (`b58f584b8`)