### PR TITLE
update: replace authenticator API routes with v1

### DIFF
--- a/docs/guides/Integration-Guides/punchout/punchout-login-integration.md
+++ b/docs/guides/Integration-Guides/punchout/punchout-login-integration.md
@@ -26,13 +26,13 @@ Example flow:
 1. Start request (VTEX user flow):
 
    ```txt
-   https://host.com/api/authenticator/punchout/start?returnURL=/checkout
+   https://host.com/api/authenticator/v1/punchout/start?returnURL=/checkout
    ```
 
 2. Finish redirect (with OTT):
 
    ```txt
-   https://host.com/api/authenticator/punchout/finish?ott=TOKEN123
+   https://host.com/api/authenticator/v1/punchout/finish?ott=TOKEN123
    ```
 
 3. Final redirect (logged-in session):
@@ -53,12 +53,12 @@ sequenceDiagram
     %% VTEX-User Flow
     alt VTEX-User Flow (Existing VTEX User)
         PU->>Proxy: Initiate Punchout Login (username, password, optional returnURL)
-        Proxy->>VTEX: POST /api/authenticator/punchout/start {username, password} + returnURL
+        Proxy->>VTEX: POST /api/authenticator/v1/punchout/start {username, password} + returnURL
         VTEX->>VTEX: Validate user credentials
         VTEX->>VTEX: Generate one-time token (OTT)
         VTEX-->>Proxy: 200 OK with URL (including OTT)
         Proxy-->>PU: Provide login URL
-        PU->>VTEX: GET /api/authenticator/punchout/finish?ott={token}
+        PU->>VTEX: GET /api/authenticator/v1/punchout/finish?ott={token}
         VTEX->>VTEX: Validate OTT and create session (set session cookie)
         alt returnURL provided
             VTEX-->>PU: 302 Redirect to validated returnURL
@@ -70,12 +70,12 @@ sequenceDiagram
     %% Pre-Authenticated User Flow
     alt Pre-Authenticated Flow (Delegated Login)
         PU->>Proxy: Initiate Delegated Punchout Login (target username, optional returnURL)
-        Proxy->>VTEX: POST /api/authenticator/punchout/authenticated/start {username} + valid auth cookie + returnURL
+        Proxy->>VTEX: POST /api/authenticator/v1/punchout/authenticated/start {username} + valid auth cookie + returnURL
         VTEX->>VTEX: Validate API key/token and permissions
         VTEX->>VTEX: Generate one-time token (OTT) with delegated subject claim
         VTEX-->>Proxy: 200 OK with URL (including OTT)
         Proxy-->>PU: Provide login URL
-        PU->>VTEX: GET /api/authenticator/punchout/finish?ott={token}
+        PU->>VTEX: GET /api/authenticator/v1/punchout/finish?ott={token}
         VTEX->>VTEX: Validate OTT and create session (set session cookie for delegated user)
         alt returnURL provided
             VTEX-->>PU: 302 Redirect to validated returnURL
@@ -89,12 +89,12 @@ sequenceDiagram
 
 This flow validates the credentials of an existing VTEX user. It requires the user’s email and password. If the validation is positive, the response provides a URL that can be accessed directly via web browsers, initiating a session in the selected host.
 
->ℹ️ Find more details about this endpoint in `POST` [Start VTEX user punchout flow](https://developers.vtex.com/docs/api-reference/punchout-api#post-/api/authenticator/punchout/start).
+>ℹ️ Find more details about this endpoint in `POST` [Start VTEX user punchout flow](https://developers.vtex.com/docs/api-reference/punchout-api#post-/api/authenticator/v1/punchout/start).
 
 ### Request example
 
 ```json
-curl -X POST "https://store.myvtex.com/api/authenticator/punchout/start?returnURL=/checkout" \
+curl -X POST "https://store.myvtex.com/api/authenticator/v1/punchout/start?returnURL=/checkout" \
   -H "Content-Type: application/json" \
   -d '{
     "username": "user@example.com",
@@ -116,12 +116,12 @@ This flow is used when the procurement user doesn’t exist on VTEX. In this cas
 
 If the validation is positive, the response provides a URL that can be accessed directly via web browsers, initiating a session created with the username provided in the request body.
 
->ℹ️ Find more details about this endpoint in `POST` [Start pre-authenticated user punchout flow](https://developers.vtex.com/docs/api-reference/punchout-api#post-/api/authenticator/punchout/authenticated/start).
+>ℹ️ Find more details about this endpoint in `POST` [Start pre-authenticated user punchout flow](https://developers.vtex.com/docs/api-reference/punchout-api#post-/api/authenticator/v1/punchout/authenticated/start).
 
 ### Request example
 
 ```json
-curl -X POST "https://store.myvtex.com/api/authenticator/punchout/authenticated/start?returnURL=/checkout" \
+curl -X POST "https://store.myvtex.com/api/authenticator/v1/punchout/authenticated/start?returnURL=/checkout" \
   -H "Content-Type: application/json" \
   -H "X-VTEX-API-AppKey: your-app-key" \
   -H "X-VTEX-API-AppToken: your-app-token" \
@@ -164,12 +164,12 @@ The finish endpoint:
   * Returns VTEX session cookies in response headers.  
   * These cookies are required for subsequent authenticated requests.
 
->ℹ️ Find more details about this endpoint in `GET` [Finish punchout login flow](https://developers.vtex.com/docs/api-reference/punchout-api#get-/api/authenticator/punchout/finish).
+>ℹ️ Find more details about this endpoint in `GET` [Finish punchout login flow](https://developers.vtex.com/docs/api-reference/punchout-api#get-/api/authenticator/v1/punchout/finish).
 
 ### Request example
 
 ```curl
-curl -X GET "https://store.myvtex.com/api/authenticator/punchout/finish?ott={one_time_token}" \
+curl -X GET "https://store.myvtex.com/api/authenticator/v1/punchout/finish?ott={one_time_token}" \
   -H "Content-Type: application/json" \
 ```
 

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-password-migration.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-password-migration.md
@@ -270,14 +270,14 @@ curl -X DELETE "https://{{accountName}}.vtexcommercestable.com.br/api/authentica
 
 ### Step 3 \- Provision legacy users
 
-When creating storefront users who should authenticate via password migration on their first login, follow the same flow described in [B2B user provisioning](https://developers.vtex.com/docs/guides/b2b-user-provisioning), setting `isLegacyPassword=true` in the query parameter of the `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users) request instead of the default `false`.
+When creating storefront users who should authenticate via password migration on their first login, follow the same flow described in [B2B user provisioning](https://developers.vtex.com/docs/guides/b2b-user-provisioning), setting `isLegacyPassword=true` in the query parameter of the `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users) request instead of the default `false`.
 
 > ⚠️ Once you create a user, you can't edit or remove it. If you upload incorrect data, create a new user with a new username.
 
 **Request example**
 
 ```shell
-curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticator/storefront/users?isLegacyPassword=true" \
+curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticator/v1/storefront/users?isLegacyPassword=true" \
   -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
   -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}" \
   -H "Content-Type: application/json" \

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -26,7 +26,7 @@ Before provisioning B2B users in VTEX, make sure the required features are enabl
 
 | Product | Category | Resource | Associated endpoints |
 | :---- | :---- | :---- | :---- |
-| VTEX ID | User Management | Create User | `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users) |
+| VTEX ID | User Management | Create User | `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users) |
 | Organization Units | Units | Edit Organization Unit | `POST` [Create organizational unit](https://developers.vtex.com/docs/api-reference/organization-units-api#post-/api/organization-units/v1) <br/><br/>`POST` [Assign user to organizational unit](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/organization-units/-organizationUnit-/users) |
 | License Manager | Services access control | Edit Storefront User Permissions | `POST` [Assign storefront roles to user](https://developers.vtex.com/docs/api-reference/storefront-permissions-api#post-/api/license-manager/storefront/users) |
 | Dynamic Storage | Dynamic storage generic resources | Insert or update document (not remove) | `POST` [Create new document](https://developers.vtex.com/docs/api-reference/masterdata-api#post-/api/dataentities/-acronym-/documents) |
@@ -68,14 +68,14 @@ At this stage, the created user is not yet linked to an organizational unit, nor
 * `identifiers`: List of login keys, indicating their type and value.
 * `isLegacyPassword`: Indicates whether the user should recover their password through an external service (`true`) or define a new password on their first login (`false`, default).
 
->ℹ️ For more information, see `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).
+>ℹ️ For more information, see `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).
 
 >⚠️ Once you create a user, you can’t edit or remove it. If you upload incorrect data, create a new user with a new username.
 
 ### Request example
 
 ```shell
-curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticator/storefront/users?isLegacyPassword=false" \
+curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticator/v1/storefront/users?isLegacyPassword=false" \
   -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
   -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
### Summary

Replace all /api/authenticator/ occurrences with /api/authenticator/v1/ in B2B user provisioning, B2B password migration, and Punchout login integration guides.

[EDU-18991](https://vtex-dev.atlassian.net/browse/EDU-18991)

relates to https://github.com/vtex/openapi-schemas/pull/1741

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [x] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs` folder, except `docs/localization`.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.


[EDU-18991]: https://vtex-dev.atlassian.net/browse/EDU-18991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ