### PR TITLE
fix: self-import en-US translations in DP Crowdin upload

### DIFF
--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -36,6 +36,7 @@ CROWDIN_WEB_BASE_DEFAULT = "https://crowdin.com"
 DOCS_SOURCE_PATH_PREFIX = "docs/"
 
 RENAME_PATH_PATTERN = re.compile(r"\{[^ ]+ => ([^}]+)\}")
+GIT_QUOTEPATH_ESCAPE_PATTERN = re.compile(r"\\([0-7]{3})")
 RENAME_STATUS_PATTERN = re.compile(r"^R\d+\t(.+)\t(.+)$")
 
 _rename_map: dict[str, str] = {}
@@ -285,9 +286,17 @@ def is_eligible_path(relative_path: str) -> bool:
     return path.startswith(DOCS_SOURCE_PATH_PREFIX)
 
 
+def decode_git_path(path: str) -> str:
+    """Decode git core.quotepath octal byte escapes (e.g. \\303\\242 -> â)."""
+    return GIT_QUOTEPATH_ESCAPE_PATTERN.sub(
+        lambda match: chr(int(match.group(1), 8)),
+        path,
+    )
+
+
 def normalize_changed_path(path: str) -> str:
     """Resolve git numstat rename syntax (dir/{old => new}) to the new path."""
-    normalized = path.replace("\\", "/").strip()
+    normalized = decode_git_path(path.strip()).replace("\\", "/")
     if "{" not in normalized or "=>" not in normalized:
         return normalized
 

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -36,7 +36,6 @@ CROWDIN_WEB_BASE_DEFAULT = "https://crowdin.com"
 DOCS_SOURCE_PATH_PREFIX = "docs/"
 
 RENAME_PATH_PATTERN = re.compile(r"\{[^ ]+ => ([^}]+)\}")
-GIT_QUOTEPATH_ESCAPE_PATTERN = re.compile(r"\\([0-7]{3})")
 RENAME_STATUS_PATTERN = re.compile(r"^R\d+\t(.+)\t(.+)$")
 
 _rename_map: dict[str, str] = {}
@@ -287,11 +286,25 @@ def is_eligible_path(relative_path: str) -> bool:
 
 
 def decode_git_path(path: str) -> str:
-    """Decode git core.quotepath octal byte escapes (e.g. \\303\\242 -> â)."""
-    return GIT_QUOTEPATH_ESCAPE_PATTERN.sub(
-        lambda match: chr(int(match.group(1), 8)),
-        path,
-    )
+    """Decode git core.quotepath octal byte escapes (e.g. relev\\303\\242ncia -> relevância)."""
+    if "\\" not in path:
+        return path
+
+    out = bytearray()
+    index = 0
+    while index < len(path):
+        if (
+            path[index] == "\\"
+            and index + 3 < len(path)
+            and path[index + 1 : index + 4].isdigit()
+            and all(ch in "01234567" for ch in path[index + 1 : index + 4])
+        ):
+            out.append(int(path[index + 1 : index + 4], 8))
+            index += 4
+            continue
+        out.extend(path[index].encode("utf-8"))
+        index += 1
+    return out.decode("utf-8")
 
 
 def normalize_changed_path(path: str) -> str:

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -3,9 +3,10 @@
 Upload PR-touched markdown files to Crowdin and update Jira descriptions
 with Crowdin metadata (word count, editor links).
 
-Developer Portal uses a single Crowdin project with en-us source files
-reviewed in the same language (no PT/ES translation pipeline). Partial
-uploads use rename-aware git diffs; numstat rename paths are normalized
+Developer Portal uses a single Crowdin project with en-US source files
+reviewed in the same language (no PT/ES translation pipeline). After source
+upload, the same content is self-imported as the en-US translation for review.
+Partial uploads use rename-aware git diffs; numstat rename paths are normalized
 in Python before processing.
 
 Commands:
@@ -45,10 +46,14 @@ def env(name: str, default: str = "") -> str:
 
 
 def crowdin_language_id() -> str:
-    language_id = env("CROWDIN_LANGUAGE", "en-us")
+    language_id = env("CROWDIN_LANGUAGE", "en-US")
     if not language_id:
         raise RuntimeError("CROWDIN_LANGUAGE is required for Crowdin uploads")
     return language_id
+
+
+def normalize_language_id(language_id: str) -> str:
+    return language_id.replace("_", "-").lower()
 
 
 def crowdin_api_base() -> str:
@@ -150,11 +155,12 @@ def fetch_project_data(project_id: str) -> dict:
 
 
 def language_editor_code(project_data: dict, language_id: str) -> str:
+    target = normalize_language_id(language_id)
     source = project_data.get("sourceLanguage") or {}
-    if source.get("id") == language_id:
+    if normalize_language_id(str(source.get("id", ""))) == target:
         return str(source["editorCode"])
     for language in project_data.get("targetLanguages") or []:
-        if language.get("id") == language_id:
+        if normalize_language_id(str(language.get("id", ""))) == target:
             return str(language["editorCode"])
     return language_id
 
@@ -176,6 +182,28 @@ def find_file(project_id: str, file_name: str) -> int | None:
         if item["data"]["name"] == file_name:
             return int(item["data"]["id"])
     return None
+
+
+def import_translation_file(
+    project_id: str,
+    file_id: int,
+    language_id: str,
+    content: bytes,
+    file_name: str,
+) -> str:
+    storage_id = upload_storage_bytes(content, file_name)
+    response = crowdin_request(
+        "POST",
+        f"/projects/{project_id}/translations/imports",
+        data={
+            "storageId": storage_id,
+            "fileId": file_id,
+            "languageIds": [language_id],
+            "importEqSuggestions": True,
+            "autoApproveImported": False,
+        },
+    )
+    return str(response["data"]["identifier"])
 
 
 def create_or_update_file(
@@ -694,6 +722,18 @@ def upload_files_to_crowdin(
             "md",
             file_context=plan.file_context if plan.mode == "partial" else None,
         )
+        import_id = import_translation_file(
+            project_id,
+            file_id,
+            language_id,
+            plan.content,
+            crowdin_name,
+        )
+        print(
+            f"Imported {crowdin_name} as {language_id} translation "
+            f"(import {import_id})",
+            file=sys.stderr,
+        )
         words = get_file_word_count(project_id, file_id)
         total_words += words
 
@@ -717,6 +757,8 @@ def upload_files_to_crowdin(
                 "addition_blocks": plan.block_count,
                 "crowdin_project_id": project_id,
                 "editor_url": editor_link,
+                "translation_import_id": import_id,
+                "translation_language_id": language_id,
             }
         )
         print(

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -6,8 +6,8 @@ with Crowdin metadata (word count, editor links).
 Developer Portal uses a single Crowdin project with en-US source files
 reviewed in the same language (no PT/ES translation pipeline). After source
 upload, the same content is self-imported as the en-US translation for review.
-Partial uploads use rename-aware git diffs; numstat rename paths are normalized
-in Python before processing.
+Partial uploads use rename-aware git diffs and block/word-count tiers on the PR diff;
+numstat rename paths are normalized in Python before processing.
 
 Commands:
   crowdin_sync.py              Upload touched files to Crowdin
@@ -501,10 +501,33 @@ def is_new_file(diff_text: str) -> bool:
     return "new file mode" in diff_text
 
 
+def count_words(text: str) -> int:
+    return len(re.findall(r"\w+", text, flags=re.UNICODE))
+
+
+def partial_upload_tier(
+    block_count: int,
+    added_words: int,
+    total_words: int,
+) -> str | None:
+    if total_words <= 0 or added_words <= 0:
+        return None
+    added_ratio = added_words / total_words
+    if block_count <= 10 and added_ratio < 0.80:
+        return "≤10 blocks and added words <80% of total"
+    if block_count <= 15 and added_ratio < 0.60 and total_words >= 2000:
+        return "≤15 blocks and added words <60% of total (≥2000 words)"
+    if block_count <= 20 and added_ratio < 0.40 and total_words >= 3000:
+        return "≤20 blocks and added words <40% of total (≥3000 words)"
+    return None
+
+
 def should_upload_partial(
     added_count: int,
     block_count: int,
     total_lines: int,
+    added_words: int,
+    total_words: int,
     *,
     new_file: bool,
 ) -> bool:
@@ -512,7 +535,7 @@ def should_upload_partial(
         return False
     if total_lines > 0 and added_count >= total_lines:
         return False
-    return block_count <= 5
+    return partial_upload_tier(block_count, added_words, total_words) is not None
 
 
 def format_partial_content(blocks: list[list[str]]) -> str:
@@ -612,21 +635,25 @@ class UploadPlan:
 def plan_upload(relative_path: str, base_sha: str, head_sha: str) -> UploadPlan:
     file_path = Path(relative_path)
     file_name = crowdin_basename(relative_path)
-    total_lines = len(file_path.read_text(encoding="utf-8").splitlines())
+    full_text = file_path.read_text(encoding="utf-8")
+    total_lines = len(full_text.splitlines())
+    total_words = count_words(full_text)
     diff_text = git_diff(base_sha, head_sha, relative_path)
     additions = parse_added_lines(diff_text)
     blocks = group_consecutive_blocks(additions)
     added_count = len(additions)
+    added_words = count_words("\n".join(text for _, text in additions))
     new_file = is_new_file(diff_text)
 
     if should_upload_partial(
         added_count,
         len(blocks),
         total_lines,
+        added_words,
+        total_words,
         new_file=new_file,
     ):
         partial_text = format_partial_content(blocks)
-        full_text = file_path.read_text(encoding="utf-8")
         changed_line_numbers = {line_no for line_no, _ in additions}
         return UploadPlan(
             mode="partial",
@@ -640,6 +667,19 @@ def plan_upload(relative_path: str, base_sha: str, head_sha: str) -> UploadPlan:
                 full_text,
                 changed_line_numbers,
             ),
+        )
+
+    if new_file or (total_lines > 0 and added_count >= total_lines):
+        print(
+            f"Using full upload for {relative_path}: new file or full rewrite",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"Using full upload for {relative_path}: "
+            f"{len(blocks)} blocks, {added_words}/{total_words} added words "
+            "outside partial tiers",
+            file=sys.stderr,
         )
 
     return UploadPlan(

--- a/.github/scripts/jira_helpers.sh
+++ b/.github/scripts/jira_helpers.sh
@@ -36,10 +36,11 @@ jira_user_search() {
 
 # Resolve PR author (GitHub login) to a Jira reporter field object.
 # Prints JSON like {"accountId":"..."} or {"name":"..."}; empty if not found.
-# Optional: GH_TOKEN (GitHub profile email), LOC_JIRA_REPORTER_EMAIL_DOMAIN (e.g. @vtex.com).
+# Optional: GH_TOKEN, PR_NUMBER, GITHUB_REPOSITORY, GITHUB_EVENT_PATH,
+# LOC_JIRA_REPORTER_EMAIL_DOMAIN (e.g. @vtex.com).
 resolve_jira_reporter_from_github() {
   local github_login="$1"
-  local candidates match_json email_query derived_email
+  local candidates match_json email_query derived_email display_name
 
   if [ -z "$github_login" ] || [ "$github_login" = "null" ]; then
     return 1
@@ -63,8 +64,66 @@ resolve_jira_reporter_from_github() {
     '
   }
 
+  pick_user_by_display_name() {
+    local name="$1"
+    jq -c --arg name "$name" --arg first "$(printf '%s' "$name" | awk '{print $1}')" \
+      --arg last "$(printf '%s' "$name" | awk '{print $NF}')" '
+      [.[] | select(.active != false)] |
+      if ($first != "" and $last != "" and ($first | ascii_downcase) != ($last | ascii_downcase)) then
+        map(select(
+          (.displayName // "" | ascii_downcase | contains($first | ascii_downcase)) and
+          (.displayName // "" | ascii_downcase | contains($last | ascii_downcase))
+        ))
+      else
+        map(select((.displayName // "" | ascii_downcase | contains($name | ascii_downcase))))
+      end |
+      .[0] // empty
+    '
+  }
+
   reporter_field_from_user() {
     jq -c 'if .accountId then {accountId: .accountId} elif .name then {name: .name} else empty end'
+  }
+
+  try_reporter_from_email() {
+    local email="$1"
+    local via="$2"
+
+    if [ -z "$email" ]; then
+      return 1
+    fi
+
+    match_json=$(jira_user_search "$email" 5 | pick_user_by_email "$email")
+    if [ -n "$match_json" ] && [ "$match_json" != "null" ]; then
+      echo "$match_json" | reporter_field_from_user
+      echo "Resolved Jira reporter for GitHub user ${github_login} via ${via}" >&2
+      return 0
+    fi
+    return 1
+  }
+
+  github_pr_commit_emails() {
+    local repo="${GITHUB_REPOSITORY:-}"
+    local pr_number="${PR_NUMBER:-}"
+
+    if [ -z "$repo" ] || [ -z "$pr_number" ]; then
+      if [ -n "${GITHUB_EVENT_PATH:-}" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+        repo=$(jq -r '.repository.full_name // empty' "$GITHUB_EVENT_PATH")
+        pr_number=$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH")
+      fi
+    fi
+
+    if [ -z "${GH_TOKEN:-}" ] || [ -z "$repo" ] || [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+      return 0
+    fi
+
+    gh api "repos/${repo}/pulls/${pr_number}/commits" --paginate \
+      --jq ".[] | select((.author.login // \"\") == \"${github_login}\") | .commit.author.email // empty" \
+      2>/dev/null \
+      | grep -i '@' \
+      | grep -vi 'users.noreply.github.com' \
+      | grep -vi 'noreply@github.com' \
+      | sort -u
   }
 
   candidates=$(jira_user_search "$github_login" 50)
@@ -75,13 +134,24 @@ resolve_jira_reporter_from_github() {
     return 0
   fi
 
+  while IFS= read -r email_query; do
+    if try_reporter_from_email "$email_query" "PR commit email ${email_query}"; then
+      return 0
+    fi
+  done <<< "$(github_pr_commit_emails)"
+
   if [ -n "${GH_TOKEN:-}" ]; then
     email_query=$(gh api "users/${github_login}" --jq '.email // empty' 2>/dev/null || true)
-    if [ -n "$email_query" ]; then
-      match_json=$(jira_user_search "$email_query" 5 | pick_user_by_email "$email_query")
+    if try_reporter_from_email "$email_query" "GitHub profile email"; then
+      return 0
+    fi
+
+    display_name=$(gh api "users/${github_login}" --jq '.name // empty' 2>/dev/null || true)
+    if [ -n "$display_name" ]; then
+      match_json=$(jira_user_search "$display_name" 20 | pick_user_by_display_name "$display_name")
       if [ -n "$match_json" ] && [ "$match_json" != "null" ]; then
         echo "$match_json" | reporter_field_from_user
-        echo "Resolved Jira reporter for GitHub user ${github_login} via GitHub email" >&2
+        echo "Resolved Jira reporter for GitHub user ${github_login} via GitHub name \"${display_name}\"" >&2
         return 0
       fi
     fi
@@ -89,10 +159,7 @@ resolve_jira_reporter_from_github() {
 
   if [ -n "${LOC_JIRA_REPORTER_EMAIL_DOMAIN:-}" ]; then
     derived_email="${github_login}${LOC_JIRA_REPORTER_EMAIL_DOMAIN}"
-    match_json=$(jira_user_search "$derived_email" 5 | pick_user_by_email "$derived_email")
-    if [ -n "$match_json" ] && [ "$match_json" != "null" ]; then
-      echo "$match_json" | reporter_field_from_user
-      echo "Resolved Jira reporter for GitHub user ${github_login} via ${derived_email}" >&2
+    if try_reporter_from_email "$derived_email" "derived email ${derived_email}"; then
       return 0
     fi
   fi

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -100,7 +100,7 @@ jobs:
           # Three-dot diff matches the GitHub PR "Files changed" tab (branch-only changes).
           DIFF_RANGE="${BASE_SHA}...${HEAD_SHA}"
 
-          INSERTIONS=$(git diff --numstat -M \
+          INSERTIONS=$(git -c core.quotepath=false diff --numstat -M \
             "$DIFF_RANGE" \
             -- docs/ \
             | awk '{sum += $1} END {print sum+0}')
@@ -111,7 +111,7 @@ jobs:
             echo "has_additions=false" >> $GITHUB_OUTPUT
           fi
 
-          CHANGED_FILES=$(git diff --numstat -M \
+          CHANGED_FILES=$(git -c core.quotepath=false diff --numstat -M \
             "$DIFF_RANGE" \
             -- docs/ \
             | awk '$1 > 0 {print $3}' \

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -5,7 +5,7 @@
 # Skips PRs with the "localization" label (case-insensitive) or l10n* branches
 # (case-insensitive). Re-add the label after new commits if it was applied before content changed.
 #
-# Developer Portal uses en-us source files reviewed in Crowdin in the same language
+# Developer Portal uses en-US source files reviewed in Crowdin in the same language
 # (single Crowdin project; no PT/ES translation pipeline).
 #
 # Label → priority/due: high = High / Friday next week; medium/low add 1–2 weeks.
@@ -17,12 +17,13 @@
 # Reporter on new tasks/subtasks: PR author (GitHub login → Jira user search;
 # optional LOC_JIRA_REPORTER_EMAIL_DOMAIN fallback, e.g. @vtex.com).
 #
-# Crowdin: uploads PR-changed files via API, sets word count on the parent and
-# language subtasks, editor links on the English revision subtask. If the Crowdin
-# upload fails, Jira/subtask creation still runs; word count and editor links are
-# skipped and a comment is posted on the parent task. Partial upload for existing
-# files with changes in ≤5 blocks (not new files); full source file is attached as
-# Crowdin file context with START/END OF UPDATED SECTION markers.
+# Crowdin: uploads PR-changed files via API, self-imports the same content as
+# en-US translation, sets word count on the parent and language subtasks, editor
+# links on the English revision subtask. If the Crowdin upload fails, Jira/subtask
+# creation still runs; word count and editor links are skipped and a comment is
+# posted on the parent task. Partial upload for existing files with changes in
+# ≤5 blocks (not new files); full source file is attached as Crowdin file context
+# with START/END OF UPDATED SECTION markers.
 #
 # Secrets — required: LOC_JIRA_BASE_URL, LOC_JIRA_USER_EMAIL, LOC_JIRA_API_TOKEN,
 # LOC_JIRA_PROJECT_KEY, LOC_JIRA_EPIC_KEY, LOC_CROWDIN_API_TOKEN,
@@ -36,7 +37,7 @@ env:
   LOC_JIRA_WORD_COUNT_FIELD: customfield_10253
   LOC_JIRA_SOURCE_LINK_PROJECT_KEY: EDU
   LOC_JIRA_REPORTER_EMAIL_DOMAIN: '@vtex.com'
-  CROWDIN_LANGUAGE: en-us
+  CROWDIN_LANGUAGE: en-US
 
 on:
   pull_request:

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -15,7 +15,7 @@
 # Links source tasks found in the PR title, description, or branch to
 # the LOC parent with a `blocks` link.
 # Reporter on new tasks/subtasks: PR author (GitHub login → Jira user search;
-# optional LOC_JIRA_REPORTER_EMAIL_DOMAIN fallback, e.g. @vtex.com).
+# PR commit email, GitHub profile/name, optional LOC_JIRA_REPORTER_EMAIL_DOMAIN).
 #
 # Crowdin: uploads PR-changed files via API, self-imports the same content as
 # en-US translation, sets word count on the parent and language subtasks, editor

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -22,7 +22,8 @@
 # links on the English revision subtask. If the Crowdin upload fails, Jira/subtask
 # creation still runs; word count and editor links are skipped and a comment is
 # posted on the parent task. Partial upload for existing files with changes in
-# ≤5 blocks (not new files); full source file is attached as Crowdin file context
+# Partial upload when the diff meets block/word-count tiers (not new files); full source
+# file is attached as Crowdin file context for partial uploads.
 # with START/END OF UPDATED SECTION markers.
 #
 # Secrets — required: LOC_JIRA_BASE_URL, LOC_JIRA_USER_EMAIL, LOC_JIRA_API_TOKEN,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix DP Crowdin en-US self-import and localization automation gaps for non-ASCII file paths.

#### Summary

- Self-import uploaded markdown as the `en-US` Crowdin translation after source upload
- Set `CROWDIN_LANGUAGE` to `en-US` and resolve editor language IDs case-insensitively
- Resolve Jira reporter from PR commit author emails when GitHub login does not match VTEX email
- Use `core.quotepath=false` in git diff and decode quotepath octal escapes before Crowdin path normalization