### PR TITLE
feat: post Jira comment when Crowdin upload succeeds

### DIFF
--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -13,6 +13,7 @@ Commands:
   crowdin_sync.py              Upload touched files to Crowdin
   crowdin_sync.py word-count   Merge word count into a Jira description (CURRENT, COUNT)
   crowdin_sync.py crowdin-links  Merge editor links into a Jira description (CURRENT, LINKS)
+  crowdin_sync.py annotate-changed-files  Add (PARTIAL|FULL) to Changed files (CURRENT, CHANGED_FILES, FILES_JSON)
 """
 
 from __future__ import annotations
@@ -719,6 +720,53 @@ def write_github_output(name: str, value: str) -> None:
         handle.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
+def build_upload_modes_for_changed_files(
+    changed_paths: list[str],
+    uploaded_files: list[dict],
+) -> dict[str, str]:
+    path_to_mode = {
+        str(record["source_path"]): str(record.get("upload_mode", "full")).upper()
+        for record in uploaded_files
+        if record.get("source_path")
+    }
+    return {path: path_to_mode.get(path, "FULL") for path in changed_paths}
+
+
+def format_annotated_changed_files_section(
+    changed_paths: list[str],
+    upload_modes: dict[str, str],
+) -> str:
+    if not changed_paths:
+        return "* No MD/MDX files changed"
+    lines = [
+        f"* {path} **({upload_modes.get(path, 'FULL')})**"
+        for path in changed_paths
+    ]
+    return "\n".join(lines)
+
+
+def merge_changed_files_description(current: str, changed_files_section: str) -> str:
+    block = f"h3. Changed files\n\n{changed_files_section.rstrip()}"
+    pattern = r"^h3\. Changed files\n\n[\s\S]*?(?=\nh3\. PR Description\b)"
+    if re.search(pattern, current, flags=re.MULTILINE):
+        return re.sub(
+            pattern,
+            block + "\n\n",
+            current.rstrip(),
+            count=1,
+            flags=re.MULTILINE,
+        )
+    if "h3. PR Description" in current:
+        return current.replace(
+            "h3. PR Description",
+            f"{block}\n\nh3. PR Description",
+            1,
+        )
+    if current.strip():
+        return f"{current.rstrip()}\n\n{block}\n"
+    return f"{block}\n"
+
+
 def merge_word_count_description(current: str, count: str) -> str:
     row = f"|Word count|{count}|"
     if re.search(r"^\|Word count\|", current, flags=re.MULTILINE):
@@ -909,12 +957,30 @@ def main() -> int:
             os.environ.get("LINKS", ""),
         ))
         return 0
+    if command == "annotate-changed-files":
+        current = os.environ.get("CURRENT", "")
+        changed_paths = [
+            line.strip()
+            for line in os.environ.get("CHANGED_FILES", "").splitlines()
+            if line.strip()
+        ]
+        uploaded_files = json.loads(os.environ.get("FILES_JSON", "[]"))
+        upload_modes = build_upload_modes_for_changed_files(
+            changed_paths,
+            uploaded_files,
+        )
+        section = format_annotated_changed_files_section(
+            changed_paths,
+            upload_modes,
+        )
+        print(merge_changed_files_description(current, section))
+        return 0
     if command == "upload":
         return upload_files()
 
     print(
         f"Unknown command: {command} "
-        "(expected upload, word-count, or crowdin-links)",
+        "(expected upload, word-count, crowdin-links, or annotate-changed-files)",
         file=sys.stderr,
     )
     return 1

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -56,6 +56,11 @@ def normalize_language_id(language_id: str) -> str:
     return language_id.replace("_", "-").lower()
 
 
+def normalize_editor_code(code: str) -> str:
+    """Crowdin editor URL segments drop separators (en-US -> enus, pt-BR -> ptbr)."""
+    return code.replace("_", "").replace("-", "").lower()
+
+
 def crowdin_api_base() -> str:
     organization = env("LOC_CROWDIN_ORGANIZATION")
     if organization:
@@ -159,12 +164,11 @@ def language_editor_code(project_data: dict, language_id: str) -> str:
     target = normalize_language_id(language_id)
     for language in project_data.get("targetLanguages") or []:
         if normalize_language_id(str(language.get("id", ""))) == target:
-            return str(language["editorCode"])
+            return normalize_editor_code(str(language["editorCode"]))
     source = project_data.get("sourceLanguage") or {}
     if normalize_language_id(str(source.get("id", ""))) == target:
-        return str(source["editorCode"])
-    # Crowdin editor codes drop hyphens (en-US -> enus), not en-us.
-    return language_id.replace("-", "").lower()
+        return normalize_editor_code(str(source["editorCode"]))
+    return normalize_editor_code(language_id)
 
 
 def editor_url(
@@ -173,7 +177,10 @@ def editor_url(
     source_editor_code: str,
     target_editor_code: str,
 ) -> str:
-    language_pair = f"{source_editor_code}-{target_editor_code}"
+    language_pair = (
+        f"{normalize_editor_code(source_editor_code)}-"
+        f"{normalize_editor_code(target_editor_code)}"
+    )
     return f"{crowdin_web_base()}/editor/{project_identifier}/{file_id}/{language_pair}"
 
 

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -155,14 +155,16 @@ def fetch_project_data(project_id: str) -> dict:
 
 
 def language_editor_code(project_data: dict, language_id: str) -> str:
+    """Resolve a Crowdin editor URL language segment (e.g. en-US -> enus)."""
     target = normalize_language_id(language_id)
-    source = project_data.get("sourceLanguage") or {}
-    if normalize_language_id(str(source.get("id", ""))) == target:
-        return str(source["editorCode"])
     for language in project_data.get("targetLanguages") or []:
         if normalize_language_id(str(language.get("id", ""))) == target:
             return str(language["editorCode"])
-    return language_id
+    source = project_data.get("sourceLanguage") or {}
+    if normalize_language_id(str(source.get("id", ""))) == target:
+        return str(source["editorCode"])
+    # Crowdin editor codes drop hyphens (en-US -> enus), not en-us.
+    return language_id.replace("-", "").lower()
 
 
 def editor_url(

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -336,7 +336,16 @@ def changed_files() -> list[str]:
     seen: set[str] = set()
     files: list[str] = []
     for line in raw.splitlines():
-        path = normalize_changed_path(line.strip())
+        stripped = line.strip()
+        if "{" in stripped and "=>" not in stripped:
+            print(
+                "[crowdin_sync] Skipping truncated rename path "
+                "(ensure CHANGED_FILES uses awk -F'\\t'): "
+                f"{stripped}",
+                file=sys.stderr,
+            )
+            continue
+        path = normalize_changed_path(stripped)
         if (
             path
             and path.endswith((".md", ".mdx"))

--- a/.github/scripts/jira_helpers.sh
+++ b/.github/scripts/jira_helpers.sh
@@ -2,6 +2,8 @@
 # Source after setting LOC_JIRA_BASE_URL, LOC_JIRA_USER_EMAIL, LOC_JIRA_API_TOKEN,
 # LOC_JIRA_PROJECT_KEY, PR_NUMBER, GITHUB_REPOSITORY, PR_REF, PR_LABEL, and GH_TOKEN.
 
+CROWDIN_UPLOAD_SUCCESS_COMMENT=$'AUTOMATIC CROWDIN UPLOAD SUCCESSFUL\n\nThe Jira ticket and subtasks were created or updated, the files were uploaded to Crowdin, and the word count and Crowdin editor links were added or updated.'
+
 # Post a plain-text comment on a Jira issue. Returns 0 on HTTP 201.
 jira_post_comment() {
   local issue_key="$1"

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -116,7 +116,7 @@ jobs:
           CHANGED_FILES=$(git -c core.quotepath=false diff --numstat -M \
             "$DIFF_RANGE" \
             -- docs/ \
-            | awk '$1 > 0 {print $3}' \
+            | awk -F'\t' '$1 > 0 {print $3}' \
             | sed 's/^"//;s/"$//' \
             | grep -E '\.(md|mdx)$' \
             | sort || true)

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -21,7 +21,8 @@
 # en-US translation, sets word count on the parent and language subtasks, editor
 # links on the English revision subtask. If the Crowdin upload fails, Jira/subtask
 # creation still runs; word count and editor links are skipped and a comment is
-# posted on the parent task. Partial upload for existing files with changes in
+# posted on the parent task. On success, a success comment is posted after subtasks
+# and word count / editor links are updated. Partial upload for existing files with changes in
 # Partial upload when the diff meets block/word-count tiers (not new files); full source
 # file is attached as Crowdin file context for partial uploads.
 # with START/END OF UPDATED SECTION markers.
@@ -1076,3 +1077,23 @@ jobs:
           else
             echo "Skipping subtask word counts (Crowdin upload failed or was skipped)"
           fi
+
+      - name: Comment on parent task for Crowdin upload success
+        if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
+          steps.content_diff.outputs.has_additions == 'true' &&
+          steps.content_diff.outputs.has_eligible_files == 'true' &&
+          steps.production_lock.outputs.updates_blocked != 'true' &&
+          steps.parent_ticket.outputs.parent_key != '' &&
+          steps.crowdin_upload.outputs.upload_succeeded == 'true'
+        env:
+          LOC_JIRA_BASE_URL: ${{ secrets.LOC_JIRA_BASE_URL }}
+          LOC_JIRA_USER_EMAIL: ${{ secrets.LOC_JIRA_USER_EMAIL }}
+          LOC_JIRA_API_TOKEN: ${{ secrets.LOC_JIRA_API_TOKEN }}
+          PARENT_KEY: ${{ steps.parent_ticket.outputs.parent_key }}
+        run: |
+          # shellcheck source=.github/scripts/jira_helpers.sh
+          source .github/scripts/jira_helpers.sh
+
+          jira_post_comment "$PARENT_KEY" "$CROWDIN_UPLOAD_SUCCESS_COMMENT"
+          echo "Posted Crowdin upload success comment on ${PARENT_KEY}"

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -571,16 +571,23 @@ jobs:
           LOC_JIRA_API_TOKEN: ${{ secrets.LOC_JIRA_API_TOKEN }}
           PARENT_KEY: ${{ steps.parent_ticket.outputs.parent_key }}
           CROWDIN_TOTAL_WORDS: ${{ steps.crowdin_upload.outputs.total_words }}
+          FILES_JSON: ${{ steps.crowdin_upload.outputs.files_json }}
+          CHANGED_FILES: ${{ steps.content_diff.outputs.changed_files }}
         run: |
           merge_word_count_description() {
             CURRENT="$1" COUNT="$2" python3 .github/scripts/crowdin_sync.py word-count
+          }
+
+          annotate_changed_files_description() {
+            CURRENT="$1" python3 .github/scripts/crowdin_sync.py annotate-changed-files
           }
 
           current_desc=$(curl -s \
             -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
             "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${PARENT_KEY}?fields=description" \
             | jq -r '.fields.description // ""')
-          merged_desc=$(merge_word_count_description "$current_desc" "$CROWDIN_TOTAL_WORDS")
+          merged_desc=$(annotate_changed_files_description "$current_desc")
+          merged_desc=$(merge_word_count_description "$merged_desc" "$CROWDIN_TOTAL_WORDS")
 
           custom_fields=$(jq -n \
             --arg field "$LOC_JIRA_WORD_COUNT_FIELD" \


### PR DESCRIPTION
## Summary

- Post **AUTOMATIC CROWDIN UPLOAD SUCCESSFUL** on the parent LOC task after upload, word count, and editor links are updated.
- Fix DP Crowdin editor links (`en-enus`) and normalize editor URL language segments.
- Parse git rename paths correctly from tab-separated numstat output.
- Annotate parent **Changed files** with **(PARTIAL)** or **(FULL)** after upload.