### PR TITLE
Remove Node builder dependency compatibility section

### DIFF
--- a/docs/guides/vtex-io/Reference/concepts/vtex-io-documentation-builders/vtex-io-documentation-node-builder.md
+++ b/docs/guides/vtex-io/Reference/concepts/vtex-io-documentation-builders/vtex-io-documentation-node-builder.md
@@ -23,12 +23,6 @@ The Node builder versions are defined in the table below. Each builder version i
 
 >⚠️ We strongly recommend upgrading your Node app to the latest Node builder before legacy Node builder versions lose the **Stable** status. For details, see [Builder version statuses](https://developers.vtex.com/docs/guides/vtex-io-documentation-builder-version-statuses). Follow the instructions in the [Node builder 7.x migration guide](https://developers.vtex.com/docs/guides/node-builder-7x-migration-guide) to upgrade your Node app.
 
-## Dependency compatibility
-
-When building Node apps, all external dependencies must be compatible with Node.js 16.x. This is the runtime version used for validation during the build process.
-
-Even if your app uses Node builder 7.x (which runs on Node.js 20.x), you still need to ensure that your libraries also support Node.js 16.x. Otherwise, the build may fail.
-
 > ⚠️ Always make sure that your dependencies are compatible with Node.js 16.x, even if your development environment or builder version runs on a newer runtime.
 
 ## Folder structure

--- a/docs/guides/vtex-io/Reference/concepts/vtex-io-documentation-builders/vtex-io-documentation-node-builder.md
+++ b/docs/guides/vtex-io/Reference/concepts/vtex-io-documentation-builders/vtex-io-documentation-node-builder.md
@@ -23,8 +23,6 @@ The Node builder versions are defined in the table below. Each builder version i
 
 >⚠️ We strongly recommend upgrading your Node app to the latest Node builder before legacy Node builder versions lose the **Stable** status. For details, see [Builder version statuses](https://developers.vtex.com/docs/guides/vtex-io-documentation-builder-version-statuses). Follow the instructions in the [Node builder 7.x migration guide](https://developers.vtex.com/docs/guides/node-builder-7x-migration-guide) to upgrade your Node app.
 
-> ⚠️ Always make sure that your dependencies are compatible with Node.js 16.x, even if your development environment or builder version runs on a newer runtime.
-
 ## Folder structure
 
 An app that uses the `node` builder has a `node` folder on its root, which contains the following files and directories:


### PR DESCRIPTION
### Summary

Removed the section on dependency compatibility for Node apps. Now that this [KI](https://help.vtex.com/known-issues/issue-with-node-version-compatibility) is resolved, Node builder 7.x is compatible with libraries that require Node.js runtime versions greater than 16.x.

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [x] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs` folder, except `docs/localization`.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.
