### PR TITLE
Fix image link in GraphQL authorization guide

### DIFF
--- a/docs/guides/vtex-io/GraphQL/graphql-authorization-in-io-apps.mdx
+++ b/docs/guides/vtex-io/GraphQL/graphql-authorization-in-io-apps.mdx
@@ -104,7 +104,7 @@ If a developer tries to build an app with the GraphQL builder `2.x`, the [VTEX I
 - The `scope` argument is missing in the directive.
 - When `scope` is `PRIVATE` in the directive and the `productCode` or `resourceCode` arguments are missing.
 
-![GraphQL auth directive error](../../images/graphql-auth-directive-error.png)
+![GraphQL auth directive error](https://cdn.jsdelivr.net/gh/vtexdocs/dev-portal-content@main/images/graphql-auth-directive-error.png)
 
 ## Making requests to protected GraphQL APIs from a VTEX IO app
 


### PR DESCRIPTION
Updated image source for GraphQL auth directive error. Change the link from reference (`../image/..`) to absolute path (`https://cdn.jsdelivr.net/gh/...`).

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [ ] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [x] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs` folder, except `docs/localization`.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.
