### PR TITLE
docs: document dpPreview parameter for testing Delivery Promise (EDU-19122)

### DIFF
--- a/docs/guides/Logistics/delivery-promise.md
+++ b/docs/guides/Logistics/delivery-promise.md
@@ -3,7 +3,7 @@ title: "Delivery Promise"
 slug: "delivery-promise"
 hidden: false
 createdAt: "2025-09-01T16:53:51.800Z"
-updatedAt: "2026-07-29T14:00:00.000Z"
+updatedAt: "2026-04-13T15:35:32.755Z"
 excerpt: "Delivery Promise helps your store show only products that can be delivered or picked up based on the customer’s location. It improves shopping experience, reduces cart abandonment, and increases product assortment visibility."
 seeAlso: 
     - "https://help.vtex.com/en/tutorial/delivery-promise-faq--2frHHK5uPsQrLK5XbYHALN"
@@ -84,14 +84,3 @@ When using a headless approach in your store, you can use the [Intelligent Searc
 ## Delivery Promise for FastStore
 
 When building your storefront with FastStore, you can enable Delivery Promise using hooks, filter options, and location priority. Learn how to apply it in the [Delivery Promise](https://developers.vtex.com/docs/guides/faststore/features-delivery-promise) guide.
-
-## Testing Delivery Promise before going live
-
-When you request Delivery Promise activation for a headless or Store Framework account, our Support team activates the feature in a `DpReady` state. This lets you test Delivery Promise without affecting production Search requests, using one of the following methods:
-
-- **Headless stores:** Add the `dpPreview=true` query parameter to Search requests that use the delivery promise information (hashes or ZIP code), as described in [Delivery Promise for headless stores](https://developers.vtex.com/docs/guides/delivery-promise-for-headless-stores). While previewing, the Intelligent Search API v1 response returns `deliveryPromiseEnabled: false`.
-- **Store Framework:** Generate a workspace and install the [Delivery Promise Components](https://developers.vtex.com/docs/apps/vtex.delivery-promise-components) app to test the feature before publishing it to your production workspace (master).
-
->ℹ️ FastStore accounts, as well as test, demo, and proof-of-concept accounts of any storefront type, are activated directly in `DpLive`, since they still require additional setup (such as installing a theme) before going live in production.
-
-Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account from `DpReady` to `DpLive`. From that point on, Search requests using the delivery promise information are considered production traffic — you no longer need the `dpPreview=true` parameter, and the API response returns `deliveryPromiseEnabled: true`.

--- a/docs/guides/Logistics/delivery-promise.md
+++ b/docs/guides/Logistics/delivery-promise.md
@@ -3,7 +3,7 @@ title: "Delivery Promise"
 slug: "delivery-promise"
 hidden: false
 createdAt: "2025-09-01T16:53:51.800Z"
-updatedAt: "2026-04-13T15:35:32.755Z"
+updatedAt: "2026-07-29T14:00:00.000Z"
 excerpt: "Delivery Promise helps your store show only products that can be delivered or picked up based on the customer’s location. It improves shopping experience, reduces cart abandonment, and increases product assortment visibility."
 seeAlso: 
     - "https://help.vtex.com/en/tutorial/delivery-promise-faq--2frHHK5uPsQrLK5XbYHALN"
@@ -84,3 +84,14 @@ When using a headless approach in your store, you can use the [Intelligent Searc
 ## Delivery Promise for FastStore
 
 When building your storefront with FastStore, you can enable Delivery Promise using hooks, filter options, and location priority. Learn how to apply it in the [Delivery Promise](https://developers.vtex.com/docs/guides/faststore/features-delivery-promise) guide.
+
+## Testing Delivery Promise before going live
+
+When you request Delivery Promise activation for a headless or Store Framework account, our Support team activates the feature in a `DpReady` state. This lets you test Delivery Promise without affecting production Search requests, using one of the following methods:
+
+- **Headless stores:** Add the `dpPreview=true` query parameter to Search requests that use the delivery promise information (hashes or ZIP code), as described in [Delivery Promise for headless stores](https://developers.vtex.com/docs/guides/delivery-promise-for-headless-stores). While previewing, the Intelligent Search API v1 response returns `deliveryPromiseEnabled: false`.
+- **Store Framework:** Generate a workspace and install the [Delivery Promise Components](https://developers.vtex.com/docs/apps/vtex.delivery-promise-components) app to test the feature before publishing it to your production workspace (master).
+
+>ℹ️ FastStore accounts, as well as test, demo, and proof-of-concept accounts of any storefront type, are activated directly in `DpLive`, since they still require additional setup (such as installing a theme) before going live in production.
+
+Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account from `DpReady` to `DpLive`. From that point on, Search requests using the delivery promise information are considered production traffic — you no longer need the `dpPreview=true` parameter, and the API response returns `deliveryPromiseEnabled: true`.

--- a/docs/guides/Search/delivery-promise-for-headless-stores.md
+++ b/docs/guides/Search/delivery-promise-for-headless-stores.md
@@ -204,7 +204,7 @@ Example:
 https://{{accountName}}.vtexcommercestable.com.br/api/intelligent-search/v1/product-search/dynamic-estimate/next-day?sc=1&deliveryZonesHash=0ecce2ea9d3b57d4ef994efba4fe3ee9&pickupPointsHash=0b79d8a9979a5f4f5f30a7849da5da16
 ```
 
-### Previewing Delivery Promise before going live
+## Previewing Delivery Promise before going live
 
 If your account is in the `DpReady` activation state, you can test Delivery Promise on Search requests without affecting production traffic. To do so, add the `dpPreview=true` query parameter together with the delivery promise information (`deliveryZonesHash` and `pickupPointsHash`, or country and ZIP code).
 

--- a/docs/guides/Search/delivery-promise-for-headless-stores.md
+++ b/docs/guides/Search/delivery-promise-for-headless-stores.md
@@ -4,7 +4,7 @@ slug: "delivery-promise-for-headless-stores"
 hidden: false
 excerpt: "Learn how to implement the delivery promise feature in headless stores."
 createdAt: "2025-05-14T22:18:24.684Z"
-updatedAt: "2026-07-29T10:00:00.000Z"
+updatedAt: "2026-07-29T14:00:00.000Z"
 ---
 
 >ℹ️ This feature is currently in [open beta](https://help.vtex.com/en/announcements/2026-07-01-delivery-promise-in-open-beta) and can be activated at both the main account and subaccount-only levels. If you want to implement it, please contact our [Support](https://support.vtex.com/hc/en-us) team to request activation.
@@ -65,6 +65,22 @@ The delivery promise information parameters are **required** to filter product a
 >⚠️ To ensure only products that are available for delivery or pickup are returned, you must include the `hideUnavailableItems=true` query parameter in your requests. If this parameter is omitted, the search engine will include products with the `ShowIfNotAvailable` property set to `true` in the Catalog module even if they are not available for delivery or pickup. For example, product `649553` may appear in results if it has `ShowIfNotAvailable` enabled, unless you explicitly set `hideUnavailableItems=true`. Learn more about the `ShowIfNotAvailable` property in the [Catalog API reference](https://developers.vtex.com/docs/api-reference/catalog-api?endpoint=get-/api/catalog_system/pvt/sku/stockkeepingunitbyid/-skuId-).
 
 For more information on facet options apart from the ones directly related to Delivery Promise, go to `GET` [Search products (v1)](https://developers.vtex.com/docs/api-reference/intelligent-search-api-v1#get-/product-search/-facets-).
+
+### Previewing Delivery Promise before going live
+
+If your account is in the `DpReady` activation state, you can test Delivery Promise on Search requests without affecting production traffic. To do so, add the `dpPreview=true` query parameter together with the delivery promise information (`deliveryZonesHash` and `pickupPointsHash`, or country and ZIP code).
+
+Example:
+
+```txt
+https://{{accountName}}.vtexcommercestable.com.br/api/intelligent-search/v1/product-search?sc=1&deliveryZonesHash=0ecce2ea9d3b57d4ef994efba4fe3ee9&pickupPointsHash=0b79d8a9979a5f4f5f30a7849da5da16&dpPreview=true
+```
+
+While previewing, the response returns `deliveryPromiseEnabled: false`.
+
+>⚠️ The `dpPreview` parameter is only supported in Intelligent Search API v1. It isn't available in [Intelligent Search API (Legacy)](https://developers.vtex.com/docs/api-reference/intelligent-search-api).
+
+Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account to the `DpLive` state. From that point on, remove the `dpPreview` parameter from your requests — Delivery Promise is applied in production, and the response returns `deliveryPromiseEnabled: true`.
 
 ### Filter combinations
 

--- a/docs/guides/Search/delivery-promise-for-headless-stores.md
+++ b/docs/guides/Search/delivery-promise-for-headless-stores.md
@@ -206,7 +206,7 @@ https://{{accountName}}.vtexcommercestable.com.br/api/intelligent-search/v1/prod
 
 ## Previewing Delivery Promise before going live
 
-If your account is in the `DpReady` activation state, you can test Delivery Promise on Search requests without affecting production traffic. To do so, add the `dpPreview=true` query parameter together with the delivery promise information (`deliveryZonesHash` and `pickupPointsHash`, or country and ZIP code).
+You can test Delivery Promise on search requests without affecting production traffic. To do so, add the `dpPreview=true` query parameter together with the delivery promise information (`deliveryZonesHash` and `pickupPointsHash`, or country and ZIP code).
 
 Example:
 
@@ -218,7 +218,7 @@ While previewing, the response returns `deliveryPromiseEnabled: false`.
 
 >⚠️ The `dpPreview` parameter is only supported in Intelligent Search API v1. It isn't available in [Intelligent Search API (Legacy)](https://developers.vtex.com/docs/api-reference/intelligent-search-api).
 
-Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account to the `DpLive` state. From that point on, remove the `dpPreview` parameter from your requests. Delivery Promise is then applied in production, and the response returns `deliveryPromiseEnabled: true`.
+Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to apply Delivery Promise in production. From that point on, remove the `dpPreview` parameter from your requests. The response will return `deliveryPromiseEnabled: true`.
 
 ## Implementing sidebar filters
 

--- a/docs/guides/Search/delivery-promise-for-headless-stores.md
+++ b/docs/guides/Search/delivery-promise-for-headless-stores.md
@@ -218,7 +218,7 @@ While previewing, the response returns `deliveryPromiseEnabled: false`.
 
 >⚠️ The `dpPreview` parameter is only supported in Intelligent Search API v1. It isn't available in [Intelligent Search API (Legacy)](https://developers.vtex.com/docs/api-reference/intelligent-search-api).
 
-Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account to the `DpLive` state. From that point on, remove the `dpPreview` parameter from your requests — Delivery Promise is applied in production, and the response returns `deliveryPromiseEnabled: true`.
+Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account to the `DpLive` state. From that point on, remove the `dpPreview` parameter from your requests. Delivery Promise is then applied in production, and the response returns `deliveryPromiseEnabled: true`.
 
 ## Implementing sidebar filters
 

--- a/docs/guides/Search/delivery-promise-for-headless-stores.md
+++ b/docs/guides/Search/delivery-promise-for-headless-stores.md
@@ -66,22 +66,6 @@ The delivery promise information parameters are **required** to filter product a
 
 For more information on facet options apart from the ones directly related to Delivery Promise, go to `GET` [Search products (v1)](https://developers.vtex.com/docs/api-reference/intelligent-search-api-v1#get-/product-search/-facets-).
 
-### Previewing Delivery Promise before going live
-
-If your account is in the `DpReady` activation state, you can test Delivery Promise on Search requests without affecting production traffic. To do so, add the `dpPreview=true` query parameter together with the delivery promise information (`deliveryZonesHash` and `pickupPointsHash`, or country and ZIP code).
-
-Example:
-
-```txt
-https://{{accountName}}.vtexcommercestable.com.br/api/intelligent-search/v1/product-search?sc=1&deliveryZonesHash=0ecce2ea9d3b57d4ef994efba4fe3ee9&pickupPointsHash=0b79d8a9979a5f4f5f30a7849da5da16&dpPreview=true
-```
-
-While previewing, the response returns `deliveryPromiseEnabled: false`.
-
->⚠️ The `dpPreview` parameter is only supported in Intelligent Search API v1. It isn't available in [Intelligent Search API (Legacy)](https://developers.vtex.com/docs/api-reference/intelligent-search-api).
-
-Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account to the `DpLive` state. From that point on, remove the `dpPreview` parameter from your requests — Delivery Promise is applied in production, and the response returns `deliveryPromiseEnabled: true`.
-
 ### Filter combinations
 
 When shoppers apply filters, the API combines them according to the following rules:
@@ -219,6 +203,22 @@ Example:
 ```txt
 https://{{accountName}}.vtexcommercestable.com.br/api/intelligent-search/v1/product-search/dynamic-estimate/next-day?sc=1&deliveryZonesHash=0ecce2ea9d3b57d4ef994efba4fe3ee9&pickupPointsHash=0b79d8a9979a5f4f5f30a7849da5da16
 ```
+
+### Previewing Delivery Promise before going live
+
+If your account is in the `DpReady` activation state, you can test Delivery Promise on Search requests without affecting production traffic. To do so, add the `dpPreview=true` query parameter together with the delivery promise information (`deliveryZonesHash` and `pickupPointsHash`, or country and ZIP code).
+
+Example:
+
+```txt
+https://{{accountName}}.vtexcommercestable.com.br/api/intelligent-search/v1/product-search?sc=1&deliveryZonesHash=0ecce2ea9d3b57d4ef994efba4fe3ee9&pickupPointsHash=0b79d8a9979a5f4f5f30a7849da5da16&dpPreview=true
+```
+
+While previewing, the response returns `deliveryPromiseEnabled: false`.
+
+>⚠️ The `dpPreview` parameter is only supported in Intelligent Search API v1. It isn't available in [Intelligent Search API (Legacy)](https://developers.vtex.com/docs/api-reference/intelligent-search-api).
+
+Once you finish testing, contact [our Support](https://support.vtex.com/hc/en-us) team to promote your account to the `DpLive` state. From that point on, remove the `dpPreview` parameter from your requests — Delivery Promise is applied in production, and the response returns `deliveryPromiseEnabled: true`.
 
 ## Implementing sidebar filters
 


### PR DESCRIPTION
### Summary

Documents how to test Delivery Promise before going live, per [EDU-19122](https://vtex-dev.atlassian.net/browse/EDU-19122). Accounts requesting activation are placed in a `DpReady` state, which lets developers test Delivery Promise on Search requests without affecting production, by adding the `dpPreview=true` query parameter (headless) before Support promotes the account to `DpLive`.

`docs/guides/Search/delivery-promise-for-headless-stores.md`:
* New "Previewing Delivery Promise before going live" (H2) section, placed after "Using Delivery Promise parameters" since it references those parameters.
* Explicitly notes that `dpPreview` is only supported in Intelligent Search API v1, not in the legacy API.

A companion change to the `openapi-schemas` repo adds the `dpPreview` parameter to the v1 `product-search` endpoint spec: https://github.com/vtex/openapi-schemas/pull/new/EDU-19122/dppreview-query-parameter

---

### Type of change

* [x] **New content** — Adds new documentation.

---

### Checklist

* [x] The content follows the VTEX Style Guide.
* [x] Markdown renders correctly (headings, lists, tables, callouts).
* [x] Links, images, code blocks, and examples are valid.
* [x] Terminology, product names, and API references are consistent.
* [x] Frontmatter (title, description, tags, slug) is correct
* [x] Files follow the expected folder structure and naming conventions.

[EDU-19122]: https://vtex-dev.atlassian.net/browse/EDU-19122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ