### PR TITLE
docs: fix release note date for VTEX Ads API rate limit note

### DIFF
--- a/docs/release-notes/2026-08-04-vtex-ads-api-reports-rate-limit.md
+++ b/docs/release-notes/2026-08-04-vtex-ads-api-reports-rate-limit.md
@@ -1,6 +1,6 @@
 ---
 title: "VTEX Ads API: Rate limit on Reports endpoints"
-slug: "2026-07-29-vtex-ads-api-reports-rate-limit"
+slug: "2026-08-04-vtex-ads-api-reports-rate-limit"
 hidden: false
 type: "info"
 createdAt: "2026-08-04T12:00:00.000Z"


### PR DESCRIPTION
Fixes the publish date on the VTEX Ads API Reports rate limit release note, which was published today but still carried a July 29 date.
