### PR TITLE
fix: update password migration endpoint links to use -name- parameter

### DIFF
--- a/docs/guides/b2b/b2b-buyer-portal/b2b-password-migration.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-password-migration.md
@@ -220,7 +220,7 @@ Once your middleware is deployed, configure the external authentication endpoint
 
 #### Upserting the configuration
 
-Use `PUT` [Upsert password migration configuration](https://developers.vtex.com/docs/api-reference/authenticator-api#put-/api/authenticator/v1/tenants/features/-featureId-) to register your middleware's URL on VTEX and enable legacy credential routing for your account.
+Use `PUT` [Upsert password migration configuration](https://developers.vtex.com/docs/api-reference/authenticator-api#put-/api/authenticator/v1/tenants/features/-name-) to register your middleware's URL on VTEX and enable legacy credential routing for your account.
 
 > ⚠️ Treat `Secret` as a credential: Don't log it, don't share it, and don't reuse it across environments.
 
@@ -240,7 +240,7 @@ curl -X PUT "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator
 
 #### Enabling or disabling the feature
 
-Use `PATCH` [Enable or disable password migration](https://developers.vtex.com/docs/api-reference/authenticator-api#patch-/api/authenticator/v1/tenants/features/-featureId-) to enable or disable password migration for your account without removing the configuration.
+Use `PATCH` [Enable or disable password migration](https://developers.vtex.com/docs/api-reference/authenticator-api#patch-/api/authenticator/v1/tenants/features/-name-) to enable or disable password migration for your account without removing the configuration.
 
 Set the `enabled` parameter to `true` to enable or `false` to disable password migration.
 
@@ -258,7 +258,7 @@ curl -X PATCH "https://{{accountName}}.vtexcommercestable.com.br/api/authenticat
 
 #### Deleting the configuration
 
-Use `DELETE` [Delete password migration configuration](https://developers.vtex.com/docs/api-reference/authenticator-api#delete-/api/authenticator/v1/tenants/features/-featureId-) to remove the password migration configuration from your account entirely.
+Use `DELETE` [Delete password migration configuration](https://developers.vtex.com/docs/api-reference/authenticator-api#delete-/api/authenticator/v1/tenants/features/-name-) to remove the password migration configuration from your account entirely.
 
 **Request example**
 


### PR DESCRIPTION
## What changed
Updated 3 anchor links in `b2b-password-migration.md` — replaced `-featureId-` with `-name-` in the fragment identifiers for the Authenticator API endpoints:

- `PUT /api/authenticator/v1/tenants/features/-name-`
- `PATCH /api/authenticator/v1/tenants/features/-name-`
- `DELETE /api/authenticator/v1/tenants/features/-name-`

## Why
The path parameter in `navigation.json` (devportal) uses `-name-`, so links using `-featureId-` were broken. This aligns the docs with the correct anchor generated by the portal.

## Related
devportal PR: https://github.com/vtexdocs/devportal/pull/1371