### PR TITLE
EDU-19229: fix Punchout checkout extension points link

### DIFF
--- a/docs/guides/Integration-Guides/punchout/punchout-cart-integration.md
+++ b/docs/guides/Integration-Guides/punchout/punchout-cart-integration.md
@@ -52,7 +52,7 @@ To implement the Punchout cart flow, you must contact our [Support team](https:/
 
 ### Implementing extension points
 
-After enabling the extension points, create a [storefront monorepo](https://developers.vtex.com/docs/guides/faststore/monorepo-overview) to customize it. Once you have set up your storefront monorepo, you’re ready to [set up Checkout extension points](https://developers.vtex.com/docs/guides/fastcheckout-setting-up).
+After enabling the extension points, create a [storefront monorepo](https://developers.vtex.com/docs/guides/faststore/monorepo-overview) to customize it. Once you have set up your storefront monorepo, you’re ready to [set up Checkout extension points](https://developers.vtex.com/docs/guides/setting-up-buyer-portal-checkout).
 
 To implement the Punchout cart flow, you must use the `punchout.order-summary.cta` extension point to send the cart data to the eprocurement system and redirect to its URL (e.g., via a “Transfer cart” or “Checkout” button).
 


### PR DESCRIPTION
Fixed a broken link in the Punchout cart integration guide that was pointing to an outdated checkout extension points reference.

## Related Task

[EDU-19229](https://vtex-dev.atlassian.net/browse/EDU-19229)


[EDU-19229]: https://vtex-dev.atlassian.net/browse/EDU-19229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ