### PR TITLE
EDU-19085: Add deletion guide card to Master Data v1 category page

### DIFF
--- a/docs/guides/Master-Data/master-data-v1/master-data-v1.md
+++ b/docs/guides/Master-Data/master-data-v1/master-data-v1.md
@@ -10,6 +10,13 @@ updatedAt: "2022-08-09T22:11:19.696Z"
 <Flex>
 
 <WhatsNextCard
+title="Deleting documents in Master Data v1"
+description="Learn how to delete Master Data v1 documents in bulk through the API."
+linkTo="https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1"
+linkTitle="See more"
+/>
+
+<WhatsNextCard
 title="Querying documents in Master Data v1"
 description="Learn how queries in VTEX Master Data v1 work"
 linkTo="https://developers.vtex.com/docs/guides/querying-documents-in-master-data-v1"


### PR DESCRIPTION
Adds the existing "Deleting documents in Master Data v1" guide as a card on the Master Data v1 category page body, which previously only linked to it from the sidebar navigation.

## Related Task

[EDU-19085](https://vtex-dev.atlassian.net/browse/EDU-19085)


[EDU-19085]: https://vtex-dev.atlassian.net/browse/EDU-19085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ