### PR TITLE
docs: fix broken image URLs in configure-tradename article

### DIFF
--- a/docs/guides/b2b/b2b-suite/settings/configure-tradename.md
+++ b/docs/guides/b2b/b2b-suite/settings/configure-tradename.md
@@ -15,30 +15,30 @@ To configure the `tradeName` field, follow the steps below:
 
 1. In VTEX Admin, go to **Store Settings** > **Storefront** > **Master Data**.
 
-![Master Data](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata1.png)
+![Master Data](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata1.png)
 
 2. After logging in, click **Advanced settings** as shown in the image below.
 
-![Advanced Settings](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata2.png)
+![Advanced Settings](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata2.png)
 
 3. In the Settings column, click on Data structure.
 
-![Data Structure](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata3.png)
+![Data Structure](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata3.png)
 
 4. Click **Data Entities**, find the CL row, and click the **Edit** button as shown in the image below.
 
-![Data Entities](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata4a.png)
+![Data Entities](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata4a.png)
 
-![Edit Customer](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata4b.png)
+![Edit Customer](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata4b.png)
 
 5. Find the **tradeName** field and click `Is filterable`.
 
-![Filterable](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata5.png)
+![Filterable](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata5.png)
 
 6. Click **Save**.
 
-![Save](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata6.png)
+![Save](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata6.png)
 
 7. Click the **Publish** button to apply the changes
 
-![Publish](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/B2B-Suite/settings/masterdata7.png)
+![Publish](https://raw.githubusercontent.com/vtexdocs/dev-portal-content/main/docs/guides/b2b/b2b-suite/settings/masterdata7.png)


### PR DESCRIPTION
## Summary

Updates the image URLs in the `configure-tradename` guide so the screenshots render on the Developers Portal.

## Changes

- Pointed all 8 `masterdata*.png` URLs from the deleted `docs/guides/B2B-Suite/settings/` path to the current `docs/guides/b2b/b2b-suite/settings/` path.

## Why

The B2B docs restructure moved the images to a new folder, but the markdown still linked to the old path. Those URLs now return 404, so the images fail to load at https://developers.vtex.com/docs/guides/configure-tradename.
