### PR TITLE
docs: link to search analytics tracking guide from mobile install guide

### DIFF
--- a/docs/guides/Activity-Flow/installing-activity-flow-in-mobile-apps.md
+++ b/docs/guides/Activity-Flow/installing-activity-flow-in-mobile-apps.md
@@ -26,3 +26,7 @@ linkTitle="See more"
 />
 
 </Flex>
+
+## Next steps
+
+To track Intelligent Search analytics events on your search screens, see [Tracking search analytics events in mobile apps](https://developers.vtex.com/docs/guides/tracking-search-analytics-events-in-mobile-apps).


### PR DESCRIPTION
## Summary
- Adds a "Next steps" link from [Installing Activity Flow in mobile apps](https://developers.vtex.com/docs/guides/installing-activity-flow-in-mobile-apps) to the new [Tracking search analytics events in mobile apps](https://developers.vtex.com/docs/guides/tracking-search-analytics-events-in-mobile-apps) guide.
- Depends on #2963 for the target page to exist.
- Related to [EDU-19325](https://vtex-dev.atlassian.net/browse/EDU-19325).

## Test plan
- [ ] Confirm the link resolves once #2963 is merged.

[EDU-19325]: https://vtex-dev.atlassian.net/browse/EDU-19325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ