### PR TITLE
EDU-19326: add API reference callout to VTEX Ads conversion guide

### DIFF
--- a/docs/guides/VTEX Ads/getting-started-with-vtex-ads-api/ads-events/conversion.md
+++ b/docs/guides/VTEX Ads/getting-started-with-vtex-ads-api/ads-events/conversion.md
@@ -23,7 +23,9 @@ Conversion tracking is crucial for measuring ad campaign effectiveness in VTEX A
 
 ## Sending a conversion event
 
-Use the `POST` [Track conversions](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/beacon/conversion) endpoint to send conversion events. Check the endpoint documentation for detailed information about all available fields.
+Use the `POST` [Track conversions](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/beacon/conversion) endpoint to send conversion events.
+
+> ℹ️ The request example below includes all required fields, plus the optional item-level fields `seller_id` and `product_id`. See the [Track conversions](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/beacon/conversion) API reference for the other optional fields, such as customer and location data, and for each field's type and whether it is required.
 
 Request example:
 


### PR DESCRIPTION
Adds an informative callout to the VTEX Ads conversion guide that directs readers to the Track conversions API reference for optional fields not shown in the request example.

## Related Task

[EDU-19326](https://vtex-dev.atlassian.net/browse/EDU-19326)


[EDU-19326]: https://vtex-dev.atlassian.net/browse/EDU-19326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ