### PR TITLE
EDU-19254: fix "Argument list too long" in the preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,9 +23,12 @@ jobs:
             **.mdx
       - name: Fetch navigation.json
         run: curl -o ./navigation.json https://developers.vtex.com/navigation.json
-      - name: Map slugs to paths
-        id: map-slugs-to-paths
+      - name: Get preview links
+        id: get-preview-links
         uses: actions/github-script@v6
+        env:
+          BRANCH: ${{ steps.get-branch-name.outputs.head_ref_branch }}
+          FILES: ${{ steps.get-changed-markdown-files.outputs.all_changed_files }}
         with:
           script: |
             const navigation = require('./navigation.json')
@@ -44,18 +47,8 @@ jobs:
             }
 
             navigation.navbar.forEach(({ slugPrefix, categories }) => slugsToPaths(slugPrefix.endsWith('/') ? slugPrefix : `${slugPrefix}/`, categories))
-            core.setOutput('slugs-to-paths', JSON.stringify(paths))
-      - name: Get preview links
-        id: get-preview-links
-        uses: actions/github-script@v6
-        env:
-          BRANCH: ${{ steps.get-branch-name.outputs.head_ref_branch }}
-          FILES: ${{ steps.get-changed-markdown-files.outputs.all_changed_files }}
-          PATHS: ${{ steps.map-slugs-to-paths.outputs.slugs-to-paths }}
-        with:
-          script: |
+
             const branch = process.env.BRANCH
-            const paths = JSON.parse(process.env.PATHS)
             const files = process.env.FILES.split(' ')
               .map(file => file.trim())
               .filter(file => file !== '')

--- a/docs/guides/VTEX-Platform-Overview/vtex-platform-overview.md
+++ b/docs/guides/VTEX-Platform-Overview/vtex-platform-overview.md
@@ -77,4 +77,3 @@ VTEX Community is an ecosystem where our clients and partners can interact, ask 
 [Support](https://help.vtex.com/en/support)
 
 All customers have access to the services provided by our Technical Support team. These specialists are extensively prepared to give you the best experience possible when solving your tickets. To contact them, you need to open a ticket with VTEX support.
-

--- a/docs/guides/VTEX-Platform-Overview/vtex-platform-overview.md
+++ b/docs/guides/VTEX-Platform-Overview/vtex-platform-overview.md
@@ -77,3 +77,4 @@ VTEX Community is an ecosystem where our clients and partners can interact, ask 
 [Support](https://help.vtex.com/en/support)
 
 All customers have access to the services provided by our Technical Support team. These specialists are extensively prepared to give you the best experience possible when solving your tickets. To contact them, you need to open a ticket with VTEX support.
+


### PR DESCRIPTION
## Summary

The `Preview Content Changes` workflow was failing on **every** pull request with `Argument list too long`, so no preview comment was posted. This merges the `Map slugs to paths` step into `Get preview links` so the site-wide slug map is built in-scope instead of being passed between steps through an environment variable.

## Changes

- Removed the `Map slugs to paths` step and moved its slug-map builder to the top of the `Get preview links` script, unchanged.
- Removed `PATHS` from the `Get preview links` `env:` block, keeping `BRANCH` and `FILES`.
- Removed `const paths = JSON.parse(process.env.PATHS)`, since `paths` is now in scope.
- Left the `Fetch navigation.json` step and all preview-URL and status logic untouched.

Net effect: 6 insertions, 13 deletions in `.github/workflows/preview.yml`.

## Why

`Map slugs to paths` serialized the whole published sidebar map and handed it to the next step via the `PATHS` environment variable. On Linux a single argument or environment string is capped at `MAX_ARG_STRLEN`, which is 32 memory pages, or 131,072 bytes. Once the docs site grew past that, `execve` failed with `E2BIG` before Node could start, which is why the failing logs show no script output at all.

Measured against the live `https://developers.vtex.com/navigation.json` on 2026-08-31:

| Metric | Value |
|---|---|
| Unique slug keys | 1,420 |
| Serialized map | 136,615 bytes |
| Full `PATHS=...` environment string | 136,621 bytes |
| `MAX_ARG_STRLEN` | 131,072 bytes |

At only about 5.5 KB over the cap, this had just tipped over, which explains why it started failing on all PRs regardless of which files changed.

Consolidating the steps removes the size-limited channel entirely rather than merely getting back under the threshold, so the failure cannot silently return as the site keeps growing. The mapping output had no other consumer, and `require('./navigation.json')` was already used in the step being removed, so no new mechanism is introduced and the navigation file that gets read is unchanged.

## Testing

Both the pre-change and post-change `script:` blocks were extracted directly from git and run against the same live navigation file and changed-files list, with the generated markdown diffed:

- Rendered preview comment: **identical**.
- Step debug logging: **identical**.
- Empty changed-files branch: **identical**.
- Branches covered: a slug listed in the navigation, a slug missing from it, and the `troubleshooting`, `release-notes`, and `faststore` cases.
- No remaining reference to `PATHS` or `map-slugs-to-paths` in the workflow.

The baseline deliberately included a path containing spaces, `docs/guides/VTEX Ads/offsite-capture/installing-the-offsite-capture-web-script.md`, to confirm this change does not alter existing behavior for those paths.

## Follow-ups (not addressed here)

Noted while investigating, each worth its own ticket:

- `FILES` is split on spaces, so a path containing a space is broken into multiple invalid entries.
- The `faststore` branch is unreachable for `docs/guides/faststore/...` paths, because `category` is `parts[1]`, which is `guides` for those files.
- `paths` is keyed by bare slug and files are matched by basename, so two pages sharing a filename in different sections can produce a wrong preview URL.
- `curl -o ./navigation.json` has no `--fail` or retry, so a failed fetch writes an error body and the workflow dies later with a confusing JSON parse error.
- `navigation-preview.yml` watches a `navigation.json` that does not exist in this repo, so it always reports no changes.
- The `Comment PR` step passes the generated table via `message:`, which becomes `INPUT_MESSAGE` and is subject to the same 128 KB cap. Only reachable on a PR with several hundred changed files.
- Outdated action versions: `actions/checkout@v3`, `actions/github-script@v6`, and `tj-actions/changed-files@v36`. The last pin especially deserves review given that action's 2025 supply-chain compromise.

## Related Task

[EDU-19254](https://vtex-dev.atlassian.net/browse/EDU-19254)


[EDU-19254]: https://vtex-dev.atlassian.net/browse/EDU-19254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ