### PR TITLE
EDU-19460: add bulk document deletion guide for Master Data

### DIFF
--- a/docs/guides/Master-Data/master-data-best-practices/bulk-deleting-documents-in-master-data.md
+++ b/docs/guides/Master-Data/master-data-best-practices/bulk-deleting-documents-in-master-data.md
@@ -1,0 +1,144 @@
+---
+title: "Bulk deleting documents in Master Data"
+slug: "bulk-deleting-documents-in-master-data"
+hidden: false
+createdAt: "2026-09-04T12:00:00.000Z"
+updatedAt: "2026-09-04T12:00:00.000Z"
+excerpt: "Learn how to delete all Master Data documents matching a filter in a single asynchronous job, and how to follow that job until it finishes."
+---
+
+In this guide, you will learn how to delete every document that matches a filter in a [Master Data](https://developers.vtex.com/docs/guides/master-data-introduction) data entity, using a single asynchronous deletion job. The job is available for both Master Data v1 and Master Data v2 data entities. When you need to remove everything matching one filter, use this job instead of the scroll and per-document `DELETE` loop described in [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1).
+
+This guide focuses on the create, poll, and confirm flow. For the full operation set, parameters, schemas, and errors, see the API reference in the following table:
+
+| Operation | Master Data v1 | Master Data v2 |
+| :---- | :---- | :---- |
+| Create bulk document deletion job | [v1](https://developers.vtex.com/docs/api-reference/masterdata-api#post-/api/dataentities/-acronym-/delete) | [v2](https://developers.vtex.com/docs/api-reference/master-data-api-v2#post-/api/dataentities/-dataEntityName-/delete) |
+| Get bulk document deletion job status | [v1](https://developers.vtex.com/docs/api-reference/masterdata-api#get-/api/dataentities/-acronym-/delete/jobs/-jobId-) | [v2](https://developers.vtex.com/docs/api-reference/master-data-api-v2#get-/api/dataentities/-dataEntityName-/delete/jobs/-jobId-) |
+
+> ❗ This action cannot be undone. Deleted documents are permanently lost. Confirm how many documents your filter matches before you create the job, so you can compare that number with the `DocumentsDeleted` value at the end.
+
+> ℹ️ To erase data for one specific customer for privacy reasons, follow [Erasing customer data](https://help.vtex.com/en/docs/tutorials/erasing-customer-data), which uses search and per-document deletion. This guide does not replace that flow.
+
+## Before you begin
+
+- Both the create and status requests require a valid [user token](https://developers.vtex.com/docs/guides/api-authentication-using-user-tokens) in the `VtexIdclientAutCookie` header.
+- The `filter` field is required and uses the same syntax as the data entity search filter. Wildcards aren't allowed.
+- Every field in the filter must be indexed. Internal fields such as `createdIn` are already indexed. Filtering on a custom field also requires the `schema` that declares it as indexed.
+- In Master Data v1, a field is indexed when it exists in the data entity and has `isSearchable` enabled. In Master Data v2, a custom field is indexed when it is listed in the `v-indexed` array of that [schema](https://developers.vtex.com/docs/guides/working-with-json-schemas-in-master-data-v2).
+- Only one deletion job can be active per account and data entity at a time. While a job is `InProgress`, creating another job for the same data entity returns `409`. Follow the existing job as described in [step 2](#2-follow-the-job-status) and send the new request once that job reaches `Success` or `Failed`. If a job appears stuck, Master Data automatically allows a new job for that data entity after 12 hours.
+- Before you create the job, search the data entity with the same filter criteria and schema, record the number of matching documents as your baseline count, and save a few of the returned document IDs. You'll use these in [step 3](#3-confirm-the-result). To learn the query patterns and count how many documents a filter matches, see [Extracting data from Master Data with search and scroll](https://developers.vtex.com/docs/guides/extracting-data-from-master-data-with-search-and-scroll).
+
+## How it works
+
+Deletion is asynchronous and runs in three steps. The create request deletes nothing by itself. It only creates the job and returns a `JobId`.
+
+1. Create the job with [Create bulk document deletion job](https://developers.vtex.com/docs/api-reference/master-data-api-v2#post-/api/dataentities/-dataEntityName-/delete).
+2. Poll [Get bulk document deletion job status](https://developers.vtex.com/docs/api-reference/master-data-api-v2#get-/api/dataentities/-dataEntityName-/delete/jobs/-jobId-) until the job reaches `Success` or `Failed`.
+3. Confirm the result against your baseline count and a follow-up search.
+
+```mermaid
+sequenceDiagram
+  participant APP as Integration
+  participant MD as Master Data API
+
+  APP->>MD: POST Create bulk document deletion job
+  MD-->>APP: 202 Accepted (JobId)
+  loop Until Status is Success or Failed
+    APP->>MD: GET Get bulk document deletion job status
+    MD-->>APP: 200 OK (Status, DocumentsDeleted)
+  end
+  APP->>MD: Search documents / Get document
+  MD-->>APP: Empty result
+```
+
+## 1. Create the deletion job
+
+Send a `POST` request to [Create bulk document deletion job](https://developers.vtex.com/docs/api-reference/master-data-api-v2#post-/api/dataentities/-dataEntityName-/delete), or to the [Master Data v1](https://developers.vtex.com/docs/api-reference/masterdata-api#post-/api/dataentities/-acronym-/delete) equivalent.
+
+The following request body filters on an internal field:
+
+```json
+{
+  "filter": "createdIn > 2026-08-16"
+}
+```
+
+The following request body filters on a custom indexed field. The `schema` field is required:
+
+```json
+{
+  "filter": "number = 1337",
+  "schema": "indexed-fields"
+}
+```
+
+A successful request returns HTTP status `202 Accepted`:
+
+```json
+{
+  "JobId": "01M08C83Z5D91S3CA0A15SRNV8"
+}
+```
+
+Save the `JobId`. It's the only way to track the operation.
+
+## 2. Follow the job status
+
+Send a `GET` request to [Get bulk document deletion job status](https://developers.vtex.com/docs/api-reference/master-data-api-v2#get-/api/dataentities/-dataEntityName-/delete/jobs/-jobId-), or to the [Master Data v1](https://developers.vtex.com/docs/api-reference/masterdata-api#get-/api/dataentities/-acronym-/delete/jobs/-jobId-) equivalent, using the `JobId` from step 1.
+
+Poll until `Status` is `Success` or `Failed`. Example response for a finished job:
+
+```json
+{
+  "Status": "Success",
+  "DocumentsDeleted": 1000
+}
+```
+
+Each status requires a different action:
+
+- `InProgress`: The job is running. Keep polling. Don't submit another job for this data entity.
+- `Success`: The job deleted all matching documents. Compare `DocumentsDeleted` with your baseline count, as described in [step 3](#3-confirm-the-result).
+- `Failed`: Processing stopped after the job exhausted its internal retries. Deletion is partial. Search the data entity with the same filter to see which documents remain, then create a new job with that filter to finish the deletion. For errors that reject a new job, see [Create bulk document deletion job](https://developers.vtex.com/docs/api-reference/master-data-api-v2#post-/api/dataentities/-dataEntityName-/delete) or the [Master Data v1](https://developers.vtex.com/docs/api-reference/masterdata-api#post-/api/dataentities/-acronym-/delete) equivalent.
+
+> ⚠️ `Failed` doesn't mean that nothing was deleted. Documents from batches the job already completed are permanently gone.
+
+The status response may include fields beyond `Status` and `DocumentsDeleted`. Ignore unexpected fields. Don't treat them as errors.
+
+## 3. Confirm the result
+
+1. Read `DocumentsDeleted` from the job status response and compare it with the baseline count you recorded before creating the job.
+2. Search the data entity again with the same filter criteria and schema, using [Search documents](https://developers.vtex.com/docs/api-reference/master-data-api-v2#get-/api/dataentities/-dataEntityName-/search) or the [Master Data v1](https://developers.vtex.com/docs/api-reference/masterdata-api#get-/api/dataentities/-acronym-/search) equivalent. It should return no documents.
+3. Send a `GET` request for one of the document IDs you saved, using [Get document](https://developers.vtex.com/docs/api-reference/master-data-api-v2#get-/api/dataentities/-dataEntityName-/documents/-id-) or the [Master Data v1](https://developers.vtex.com/docs/api-reference/masterdata-api#get-/api/dataentities/-acronym-/documents/-id-) equivalent. It should return an empty response.
+
+After the documents are deleted, they are no longer counted in stored volume.
+
+## Error reference
+
+### `POST /api/dataentities/{name}/delete`
+
+| HTTP status | Message or cause | Action |
+| :---- | :---- | :---- |
+| `400` | `The 'filter' field is required` | Send the `filter` field in the body. |
+| `400` | `Wildcard filters are not allowed for bulk delete` | Rewrite the filter using exact or range conditions over indexed fields. |
+| `400` | `The field '{field}' is not an internal indexed field, so the 'schema' that declares it as indexed must be provided` | Add `schema` to the body, as in Example B. |
+| `400` | `The field {field} is not indexed in the schema {schema}...` | Mark the field as indexed in the schema and wait for reindexing, or filter on a field that is already indexed. |
+| `400` | `The field '{field}' does not exist for the data entity '{entity}'` | Correct the field name in the filter. |
+| `400` | `The field {field} of the data entity {entity} is not indexed (isSearchable is not enabled)...` | Enable `isSearchable` on the field and wait for reindexing, or use another indexed field. |
+| `400` | `Invalid data entity name` | Correct the data entity name in the URL. Invalid characters are rejected. |
+| `409` | `Bulk deletion job creation failed for {entity}`. A job is already `InProgress` for this account and data entity. | Follow the existing job as described in step 2 and send the request again once it reaches a terminal state. If a job appears stuck, the lock is released automatically after 12 hours. |
+| `415` | No request body was sent. | Send a JSON body with the `Content-Type: application/json` header. |
+| `5xx` | Transient infrastructure failure during job creation. | No residual state is left behind. Send the request again. |
+
+### `GET /api/dataentities/{name}/delete/jobs/{jobId}`
+
+| HTTP status | Cause | Action |
+| :---- | :---- | :---- |
+| `404` | The `jobId` does not exist for this account and data entity, or the job is older than the retention window. | Check the `jobId` and the data entity name in the URL. |
+
+## Next steps
+
+- [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1): The difference between data entities and documents, per-document deletion for selective cleanups, and how to recover access to a data entity that was deleted from the Master Data v1 interface
+- [Extracting data from Master Data with search and scroll](https://developers.vtex.com/docs/guides/extracting-data-from-master-data-with-search-and-scroll): How to query the documents a filter matches before deleting them
+- [Master Data API v1 reference](https://developers.vtex.com/docs/api-reference/masterdata-api) and [Master Data API v2 reference](https://developers.vtex.com/docs/api-reference/master-data-api-v2): Parameters, schemas, and errors for both versions

--- a/docs/guides/Master-Data/master-data-best-practices/bulk-deleting-documents-in-master-data.md
+++ b/docs/guides/Master-Data/master-data-best-practices/bulk-deleting-documents-in-master-data.md
@@ -9,6 +9,8 @@ excerpt: "Learn how to delete all Master Data documents matching a filter in a s
 
 In this guide, you will learn how to delete every document that matches a filter in a [Master Data](https://developers.vtex.com/docs/guides/master-data-introduction) data entity, using a single asynchronous deletion job. The job is available for both Master Data v1 and Master Data v2 data entities. When you need to remove everything matching one filter, use this job instead of the scroll and per-document `DELETE` loop described in [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1).
 
+> ⚠️ This feature is in closed beta, meaning only specific customers can access it now. If you want to implement it in the future, please contact [our Support](https://support.vtex.com/hc/en-us/).
+
 This guide focuses on the create, poll, and confirm flow. For the full operation set, parameters, schemas, and errors, see the API reference in the following table:
 
 | Operation | Master Data v1 | Master Data v2 |

--- a/docs/guides/Master-Data/master-data-best-practices/master-data-best-practices.md
+++ b/docs/guides/Master-Data/master-data-best-practices/master-data-best-practices.md
@@ -6,6 +6,7 @@ hidden: false
 createdAt: "2022-07-05T19:11:40.758Z"
 updatedAt: "2022-07-05T20:08:04.515Z"
 ---
+
 Below, you can check some guides to help you get started with Master Data.
 
 ## Manage documents
@@ -17,6 +18,8 @@ See Master Data v2 endpoints for managing documents:
 - `PUT` - [Update entire document](https://developers.vtex.com/docs/api-reference/master-data-api-v2#put-/api/dataentities/-dataEntityName-/documents/-id-) 
 - `PATCH` - [Update partial document](https://developers.vtex.com/docs/api-reference/master-data-api-v2#patch-/api/dataentities/-dataEntityName-/documents/-id-)
 - `DELETE` - [Delete document](https://developers.vtex.com/docs/api-reference/master-data-api-v2#delete-/api/dataentities/-dataEntityName-/documents/-id-)
+
+> ℹ️ To delete documents in bulk, see [Bulk deleting documents in Master Data](/docs/guides/bulk-deleting-documents-in-master-data).
 
 ## Customize data entities
 

--- a/docs/guides/Master-Data/master-data-v1/deleting-documents-in-master-data-v1.md
+++ b/docs/guides/Master-Data/master-data-v1/deleting-documents-in-master-data-v1.md
@@ -6,12 +6,15 @@ createdAt: "2026-07-08T21:34:00.000Z"
 updatedAt: "2026-07-08T21:34:00.000Z"
 excerpt: "Learn how to delete Master Data v1 documents in bulk through the API to reduce stored volume, and how to recover access when an entity was removed from the Master Data v1 interface."
 seeAlso:
+ - "/docs/guides/bulk-deleting-documents-in-master-data"
  - "/docs/guides/extracting-data-from-master-data-with-search-and-scroll"
  - "/docs/guides/pagination-in-the-master-data-api"
  - "/docs/guides/querying-documents-in-master-data-v1"
 ---
 
 This guide explains how to delete documents in [custom data entities](https://help.vtex.com/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#custom-data-entities) in Master Data v1 through the [Master Data API v1](https://developers.vtex.com/docs/api-reference/masterdata-api) to reduce stored volume and billing. The flow uses [Scroll documents](https://developers.vtex.com/docs/api-reference/masterdata-api#get-/api/dataentities/-acronym-/scroll) to list document IDs and [Delete document](https://developers.vtex.com/docs/api-reference/masterdata-api#delete-/api/dataentities/-acronym-/documents/-id-) to remove each record.
+
+> ℹ️ To delete every document matching a filter, use the bulk deletion job instead of the flow below. A single request creates an asynchronous job that removes all matching documents, so you do not have to scroll the entity and delete each record. See [Bulk deleting documents in Master Data](https://developers.vtex.com/docs/guides/bulk-deleting-documents-in-master-data). Use the flow below when you need to delete a specific set of document IDs, or when the entity has no indexed field you can filter on.
 
 > ℹ️ To erase data for one specific customer for privacy reasons, follow [Erasing customer data](https://help.vtex.com/en/tutorial/erasing-customer-data--1R9Fn7A06Ifj4R9YD4JTKU), which uses [Search documents](https://developers.vtex.com/docs/api-reference/masterdata-api#get-/api/dataentities/-acronym-/search) and [Delete document](https://developers.vtex.com/docs/api-reference/masterdata-api#delete-/api/dataentities/-acronym-/documents/-id-). This guide does not replace that flow.
 

--- a/docs/release-notes/2026-09-04-master-data-api-bulk-document-deletion.md
+++ b/docs/release-notes/2026-09-04-master-data-api-bulk-document-deletion.md
@@ -1,0 +1,29 @@
+---
+title: "Master Data API: Bulk document deletion for v1 and v2 entities"
+slug: "2026-09-04-master-data-api-bulk-document-deletion"
+hidden: false
+type: "added"
+createdAt: "2026-09-04T12:00:00.000Z"
+excerpt: "Master Data v1 and v2 entities now support an asynchronous job that deletes every document matching a filter in a single operation. Existing integrations require no action."
+---
+
+The [Master Data](https://developers.vtex.com/docs/guides/master-data-introduction) API now offers a bulk deletion job for v1 and v2 entities. In a single operation, the job removes every document of a data entity matching a filter.
+
+## What has changed?
+
+Previously, deleting many documents required [scrolling through the data entity](https://developers.vtex.com/docs/guides/extracting-data-from-master-data-with-search-and-scroll) and sending one `DELETE` request per document. Now you can delete Master Data documents in bulk with just a single deletion job.
+
+The API now exposes two operations:
+
+- `POST /api/dataentities/{name}/delete` creates the job and returns `202 Accepted` with a `JobId`. The request itself deletes nothing.
+- `GET /api/dataentities/{name}/delete/jobs/{jobId}` returns the job status and the number of documents deleted.
+
+Deletion is asynchronous, so you can poll the job until it succeeds or fails.
+
+## What needs to be done?
+
+No action is required. Per-document deletion is unchanged and still supported for selective cleanups and privacy erasure flows.
+
+> ❗ Bulk deletion cannot be undone, deleted documents are permanently lost.
+
+To adopt the new job, follow [Bulk deleting documents in Master Data](https://developers.vtex.com/docs/guides/bulk-deleting-documents-in-master-data), which covers filter rules, polling, and error handling.


### PR DESCRIPTION
## Summary

Documents the new Master Data bulk document deletion job for v1 and v2 data entities: a single asynchronous request that deletes every document matching a filter, instead of scrolling the entity and issuing one `DELETE` per document.

## Changes

- Add [Bulk deleting documents in Master Data](docs/guides/Master-Data/master-data-best-practices/bulk-deleting-documents-in-master-data.md): create/poll/confirm flow, filter and indexing rules, and an error reference for both `POST .../delete` and `GET .../delete/jobs/{jobId}`.
- Add release note [2026-09-04-master-data-api-bulk-document-deletion.md](docs/release-notes/2026-09-04-master-data-api-bulk-document-deletion.md) announcing the new job.
- Update [master-data-best-practices.md](docs/guides/Master-Data/master-data-best-practices/master-data-best-practices.md) with a cross-link to the new guide.
- Update [deleting-documents-in-master-data-v1.md](docs/guides/Master-Data/master-data-v1/deleting-documents-in-master-data-v1.md) with a `seeAlso` entry and an inline note pointing readers to the bulk job when they don't need per-document deletion.

## Related Task

[EDU-19460](https://vtex-dev.atlassian.net/browse/EDU-19460)


[EDU-19460]: https://vtex-dev.atlassian.net/browse/EDU-19460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ