### PR TITLE
Document marketplace paymentData on seller orders for NT 2025.001 (EDU-19476)

### DIFF
--- a/docs/guides/Getting-Started/payments-overview.md
+++ b/docs/guides/Getting-Started/payments-overview.md
@@ -24,6 +24,8 @@ The key components are:
 
 There are three [purchase flows](https://developers.vtex.com/docs/guides/payments-integration-purchase-flows) available: **Transparent** (the shopper stays on the VTEX checkout), **Redirect** (the shopper is sent to the provider's page), and **Payment App** (custom payment UX built with VTEX IO).
 
+When a marketplace processes the shopper’s payment, the seller order can still include native `paymentData` for invoicing. That object is not a Gateway transaction on the seller account. See [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
+
 ## Integration paths
 
 VTEX supports three types of payment-related integrations. Each uses a dedicated protocol that defines the endpoints your connector must implement.

--- a/docs/guides/Getting-Started/payments-overview.md
+++ b/docs/guides/Getting-Started/payments-overview.md
@@ -24,7 +24,7 @@ The key components are:
 
 There are three [purchase flows](https://developers.vtex.com/docs/guides/payments-integration-purchase-flows) available: **Transparent** (the shopper stays on the VTEX checkout), **Redirect** (the shopper is sent to the provider's page), and **Payment App** (custom payment UX built with VTEX IO).
 
-When a marketplace processes the shopper’s payment, the seller order can still include native `paymentData` for invoicing. That object is not a Gateway transaction on the seller account. See [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
+When a marketplace processes the customer's payment, the seller order can still include native `paymentData` for invoicing. That object isn't a Gateway transaction on the seller account. See [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
 
 ## Integration paths
 

--- a/docs/guides/Integration-Guides/external-seller-integration-guide/external-seller-processing-payments.md
+++ b/docs/guides/Integration-Guides/external-seller-integration-guide/external-seller-processing-payments.md
@@ -7,8 +7,8 @@ updatedAt: "2022-02-03T13:21:17.263Z"
 ---
 Although in our [marketplace / seller architecture](https://developers.vtex.com/docs/guides/external-marketplace-integration-architecture) payments are usually processed by the marketplace, this can also be done by the seller. This decision of where to process payments depends on the commercial conditions they have negotiated with the payment provider.  Therefore, there are two possibilities for processing payments:
 
-- **Marketplace processing payments:** the seller does not configure a Gateway to process the shopper's payment. Invoice integrations must still read `paymentData` on the seller order, as described in [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
-- **External seller processing payments:** seller should follow the instructions below.
+- **Marketplace processing payments:** The seller doesn't configure a Gateway to process the customer's payment. If you issue invoices, read `paymentData` on the seller order, as described in [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
+- **External seller processing payments:** Follow the instructions in this guide.
 
 ## Split Payments
 

--- a/docs/guides/Integration-Guides/external-seller-integration-guide/external-seller-processing-payments.md
+++ b/docs/guides/Integration-Guides/external-seller-integration-guide/external-seller-processing-payments.md
@@ -7,7 +7,7 @@ updatedAt: "2022-02-03T13:21:17.263Z"
 ---
 Although in our [marketplace / seller architecture](https://developers.vtex.com/docs/guides/external-marketplace-integration-architecture) payments are usually processed by the marketplace, this can also be done by the seller. This decision of where to process payments depends on the commercial conditions they have negotiated with the payment provider.  Therefore, there are two possibilities for processing payments:
 
-- **Marketplace processing payments:** no development is needed from the seller.
+- **Marketplace processing payments:** the seller does not configure a Gateway to process the shopper's payment. Invoice integrations must still read `paymentData` on the seller order, as described in [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
 - **External seller processing payments:** seller should follow the instructions below.
 
 ## Split Payments

--- a/docs/guides/Integration-Guides/payments-integration-guide.md
+++ b/docs/guides/Integration-Guides/payments-integration-guide.md
@@ -59,6 +59,12 @@ The articles listed below present the characteristics and mode of operation of o
 | [Managing VTEX gift cards](https://developers.vtex.com/docs/guides/managing-vtex-gift-cards)                             | How to create, update, and manage native VTEX gift cards via API.                   |
 | [Configuring an external gift card provider](https://developers.vtex.com/docs/guides/configuring-an-external-gift-card-provider) | How to register an external gift card provider and implement the integration flows used by VTEX Gift Card Hub. |
 
+### Marketplace
+
+| Article                                                                                                                       | Description                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders) | How seller orders receive native `paymentData` for invoicing when the marketplace processes the payment. |
+
 ### Operations & Configuration
 
 | Article                                                                                                                           | Description                                                                        |

--- a/docs/guides/Integration-Guides/payments-integration-guide/marketplace-payment-data-on-seller-orders.md
+++ b/docs/guides/Integration-Guides/payments-integration-guide/marketplace-payment-data-on-seller-orders.md
@@ -1,0 +1,91 @@
+---
+title: "Marketplace payment data on seller orders"
+slug: "marketplace-payment-data-on-seller-orders"
+hidden: false
+createdAt: "2026-09-10T00:00:00.000Z"
+updatedAt: "2026-09-10T00:00:00.000Z"
+excerpt: "How native paymentData on marketplace seller orders carries NT 2025.001 fiscal fields without creating a VTEX Gateway transaction on the seller account."
+---
+
+When a marketplace processes the shopper’s payment, the seller order can include native `paymentData` with the method used on the marketplace. VTEX uses this object so merchants can fill invoices — in Brazil, the fields required by [NT 2025.001](https://developers.vtex.com/updates/release-notes/2025-08-29-orders-api-support-for-nt-2025-001-fields).
+
+> ⚠️ This `paymentData` is **not** a payment transaction on the seller’s [VTEX Payment Gateway](https://help.vtex.com/en/tutorial/what-is-a-payment-gateway--2KH9Wdi7F6swOU4amECSOk). Do not use it to authorize, settle, refund, or capture a payment on the seller account.
+
+This behavior applies to VTEX sellers and to external sellers that receive the [Authorize fulfillment](https://developers.vtex.com/docs/api-reference/marketplace-protocol-external-seller-fulfillment#post-/pvt/orders/-sellerOrderId-/fulfill) payload. It does not replace [Split Payouts on Payment Provider Protocol](https://developers.vtex.com/docs/guides/split-payouts-on-payment-provider-protocol), which describes real split processing on the marketplace Gateway.
+
+## How to identify a marketplace-assumed payment
+
+In the VTEX Admin, the order payment section can show the real method, such as **Credit card** and **Mastercard**. The signal that the marketplace assumed the payment is the **Transaction ID** `PAYMENT-FROM-AFFILIATE`.
+
+The same value is stored as `transactionId` in the order. The date under **Gateway authorization** does not mean that the seller Gateway authorized the payment.
+
+Older integrations may still show `paymentSystemName` as *Assumed value by affiliate*. Treat `transactionId = "PAYMENT-FROM-AFFILIATE"` as the identifier going forward.
+
+## Payload
+
+Read `paymentData` from [Get order](https://developers.vtex.com/docs/api-reference/orders-api#get-/api/oms/pvt/orders/-orderId-). External sellers can also receive it in [Authorize fulfillment](https://developers.vtex.com/docs/api-reference/marketplace-protocol-external-seller-fulfillment#post-/pvt/orders/-sellerOrderId-/fulfill) after `placeOrder`.
+
+```json
+{
+  "transactionId": "PAYMENT-FROM-AFFILIATE",
+  "payments": [
+    {
+      "paymentSystem": "21",
+      "paymentSystemName": "JCB",
+      "value": 100000,
+      "installments": 1,
+      "referenceValue": 100000,
+      "group": "creditCard",
+      "connectorResponses": {
+        "acquirerCnpj": "01425787000104",
+        "authId": "01010202"
+      }
+    }
+  ]
+}
+```
+
+`connectorResponses` may also include a `Message` that states the value was assumed by the affiliate. Do not treat that text as a Gateway operation result.
+
+## NT 2025.001 fields
+
+The previous approach stored NT fields in `customData.customApps`. Native `paymentData` maps them as follows:
+
+| NT / `customApps` field | Native `paymentData` field |
+| --- | --- |
+| `marketplacePaymentMethods` | `group`, `paymentSystem`, and `paymentSystemName` |
+| `marketplacePaymentCreditCardBrands` | `paymentSystemName` (card brand, when applicable) |
+| `marketplacePaymentAuthorizationCodes` | `connectorResponses.authId` |
+| `marketplacePaymentCnpjAcquirers` | `connectorResponses.acquirerCnpj` |
+
+Phase 1 of the marketplace integration still sends `customApps` in addition to `paymentData`. Prefer the native fields for new invoice integrations. Not every marketplace connector uses this payload yet.
+
+## Payment system mapping
+
+When the marketplace method matches a VTEX payment system by name, the order uses that system’s catalog `id` (`paymentSystem`) and `groupName` (`group`). Examples:
+
+| Marketplace method (matched by name) | `paymentSystem` | `paymentSystemName` | `group` |
+| --- | --- | --- | --- |
+| JCB | `"21"` | `JCB` | `creditCard` |
+| Débito Itau | `"22"` | `Débito Itau` | `debit` |
+
+If there is no match:
+
+- `paymentSystem` is `"0"`.
+- `paymentSystemName` keeps the label sent by the marketplace.
+- `group` is promissory.
+
+Marketplace labels are not standardized. `CARD`, `Credit Card`, and `credit_card` can all arrive for the same method. Unmapped values must not block the order.
+
+## What not to do
+
+- Do not call [Payments Gateway API](https://developers.vtex.com/docs/api-reference/payments-gateway-api) endpoints such as Get transaction on the seller account and expect a PCI transaction only because `paymentData` is filled.
+- Do not send NT field names (`marketplacePaymentMethods`, `marketplacePaymentCnpjAcquirers`, and similar) inside `connectorResponses`. Use `acquirerCnpj` and `authId`.
+- Do not use `tid` or `nsu` as the documented contract for this flow. The fields aligned with Payments are `acquirerCnpj`, `authId`, and, when present, `Message`.
+
+## See also
+
+- [Payments in VTEX marketplaces](https://help.vtex.com/en/docs/tutorials/payments-in-vtex-marketplaces)
+- [Fetching marketplace information with the Orders API](https://developers.vtex.com/docs/guides/get-marketplace-data-orders-api)
+- [External seller processing payments](https://developers.vtex.com/docs/guides/external-seller-processing-payments)
+- [Orders API: support for NT 2025.001 fields](https://developers.vtex.com/updates/release-notes/2025-08-29-orders-api-support-for-nt-2025-001-fields)

--- a/docs/guides/Integration-Guides/payments-integration-guide/marketplace-payment-data-on-seller-orders.md
+++ b/docs/guides/Integration-Guides/payments-integration-guide/marketplace-payment-data-on-seller-orders.md
@@ -7,23 +7,23 @@ updatedAt: "2026-09-10T00:00:00.000Z"
 excerpt: "How native paymentData on marketplace seller orders carries NT 2025.001 fiscal fields without creating a VTEX Gateway transaction on the seller account."
 ---
 
-When a marketplace processes the shopper’s payment, the seller order can include native `paymentData` with the method used on the marketplace. VTEX uses this object so merchants can fill invoices — in Brazil, the fields required by [NT 2025.001](https://developers.vtex.com/updates/release-notes/2025-08-29-orders-api-support-for-nt-2025-001-fields).
+When a marketplace processes the customer's payment, the seller order can include native `paymentData` with the method used on the marketplace. Use this object to issue invoices. In Brazil, it carries the fields required by [NT 2025.001](https://developers.vtex.com/updates/release-notes/2025-08-29-orders-api-support-for-nt-2025-001-fields).
 
-> ⚠️ This `paymentData` is **not** a payment transaction on the seller’s [VTEX Payment Gateway](https://help.vtex.com/en/tutorial/what-is-a-payment-gateway--2KH9Wdi7F6swOU4amECSOk). Do not use it to authorize, settle, refund, or capture a payment on the seller account.
+> ⚠️ This `paymentData` isn't a payment transaction on the seller’s [VTEX Payment Gateway](https://help.vtex.com/en/tutorial/what-is-a-payment-gateway--2KH9Wdi7F6swOU4amECSOk). Don't use it to authorize, settle, refund, or capture a payment on the seller account.
 
-This behavior applies to VTEX sellers and to external sellers that receive the [Authorize fulfillment](https://developers.vtex.com/docs/api-reference/marketplace-protocol-external-seller-fulfillment#post-/pvt/orders/-sellerOrderId-/fulfill) payload. It does not replace [Split Payouts on Payment Provider Protocol](https://developers.vtex.com/docs/guides/split-payouts-on-payment-provider-protocol), which describes real split processing on the marketplace Gateway.
+This behavior applies to VTEX sellers and to external sellers that receive the [Authorize fulfillment](https://developers.vtex.com/docs/api-reference/marketplace-protocol-external-seller-fulfillment#post-/pvt/orders/-sellerOrderId-/fulfill) payload. It doesn't replace [Split Payouts on Payment Provider Protocol](https://developers.vtex.com/docs/guides/split-payouts-on-payment-provider-protocol), which describes split processing on the marketplace Gateway.
 
-## How to identify a marketplace-assumed payment
+## Identifying a marketplace-assumed payment
 
-In the VTEX Admin, the order payment section can show the real method, such as **Credit card** and **Mastercard**. The signal that the marketplace assumed the payment is the **Transaction ID** `PAYMENT-FROM-AFFILIATE`.
+In the VTEX Admin, open the order and go to **Payment**. The section can show the real method, such as **Credit card** and **Mastercard**. The signal that the marketplace assumed the payment is the **Transaction ID** `PAYMENT-FROM-AFFILIATE`.
 
-The same value is stored as `transactionId` in the order. The date under **Gateway authorization** does not mean that the seller Gateway authorized the payment.
+The same value is stored as `transactionId` in the order. The date in **Gateway authorization** doesn't mean that the Gateway of the seller account authorized the payment.
 
-Older integrations may still show `paymentSystemName` as *Assumed value by affiliate*. Treat `transactionId = "PAYMENT-FROM-AFFILIATE"` as the identifier going forward.
+Older integrations may still show `paymentSystemName` as *Assumed value by affiliate*. Use `transactionId = "PAYMENT-FROM-AFFILIATE"` as the identifier going forward.
 
-## Payload
+## Reading the payload
 
-Read `paymentData` from [Get order](https://developers.vtex.com/docs/api-reference/orders-api#get-/api/oms/pvt/orders/-orderId-). External sellers can also receive it in [Authorize fulfillment](https://developers.vtex.com/docs/api-reference/marketplace-protocol-external-seller-fulfillment#post-/pvt/orders/-sellerOrderId-/fulfill) after `placeOrder`.
+Read `paymentData` from the [Get order](https://developers.vtex.com/docs/api-reference/orders-api#get-/api/oms/pvt/orders/-orderId-) endpoint. External sellers can also receive it in [Authorize fulfillment](https://developers.vtex.com/docs/api-reference/marketplace-protocol-external-seller-fulfillment#post-/pvt/orders/-sellerOrderId-/fulfill) after `placeOrder`.
 
 ```json
 {
@@ -45,11 +45,11 @@ Read `paymentData` from [Get order](https://developers.vtex.com/docs/api-referen
 }
 ```
 
-`connectorResponses` may also include a `Message` that states the value was assumed by the affiliate. Do not treat that text as a Gateway operation result.
+`connectorResponses` may also include a `Message` that states the value was assumed by the affiliate. Don't treat that text as a Gateway operation result.
 
 ## NT 2025.001 fields
 
-The previous approach stored NT fields in `customData.customApps`. Native `paymentData` maps them as follows:
+Nota Técnica (NT) 2025.001 fields were previously stored in `customData.customApps`. Native `paymentData` maps them as follows:
 
 | NT / `customApps` field | Native `paymentData` field |
 | --- | --- |
@@ -58,11 +58,11 @@ The previous approach stored NT fields in `customData.customApps`. Native `payme
 | `marketplacePaymentAuthorizationCodes` | `connectorResponses.authId` |
 | `marketplacePaymentCnpjAcquirers` | `connectorResponses.acquirerCnpj` |
 
-Phase 1 of the marketplace integration still sends `customApps` in addition to `paymentData`. Prefer the native fields for new invoice integrations. Not every marketplace connector uses this payload yet.
+Some connectors still send `customApps` in addition to `paymentData`. Prefer the native fields for new invoice integrations. Not every marketplace connector uses this payload yet.
 
-## Payment system mapping
+## Mapping payment systems
 
-When the marketplace method matches a VTEX payment system by name, the order uses that system’s catalog `id` (`paymentSystem`) and `groupName` (`group`). Examples:
+When the marketplace method matches a VTEX payment system by name, the order uses that system's catalog `id` (`paymentSystem`) and `groupName` (`group`). Examples:
 
 | Marketplace method (matched by name) | `paymentSystem` | `paymentSystemName` | `group` |
 | --- | --- | --- | --- |
@@ -75,13 +75,13 @@ If there is no match:
 - `paymentSystemName` keeps the label sent by the marketplace.
 - `group` is promissory.
 
-Marketplace labels are not standardized. `CARD`, `Credit Card`, and `credit_card` can all arrive for the same method. Unmapped values must not block the order.
+Marketplace labels aren't standardized. `CARD`, `Credit Card`, and `credit_card` can all arrive for the same method. Unmapped values must not block the order.
 
-## What not to do
+## Avoiding Gateway actions
 
-- Do not call [Payments Gateway API](https://developers.vtex.com/docs/api-reference/payments-gateway-api) endpoints such as Get transaction on the seller account and expect a PCI transaction only because `paymentData` is filled.
-- Do not send NT field names (`marketplacePaymentMethods`, `marketplacePaymentCnpjAcquirers`, and similar) inside `connectorResponses`. Use `acquirerCnpj` and `authId`.
-- Do not use `tid` or `nsu` as the documented contract for this flow. The fields aligned with Payments are `acquirerCnpj`, `authId`, and, when present, `Message`.
+- Don't call [Payments Gateway API](https://developers.vtex.com/docs/api-reference/payments-gateway-api) endpoints such as the Get transaction endpoint on the seller account and expect a transaction only because `paymentData` is present.
+- Don't send NT field names (`marketplacePaymentMethods`, `marketplacePaymentCnpjAcquirers`, and similar) inside `connectorResponses`. Use `acquirerCnpj` and `authId`.
+- Don't use `tid` or `nsu` in this flow. Use `acquirerCnpj`, `authId`, and, when present, `Message`.
 
 ## See also
 

--- a/readme-api-md/Payments Gateway API/payments-gateway-api-overview.md
+++ b/readme-api-md/Payments Gateway API/payments-gateway-api-overview.md
@@ -14,4 +14,4 @@ updatedAt: "2022-06-15T19:38:22.663Z"
 [/block]
 The Payments Gateway API allows you to get payment data and process your store's transactions.
 
-> ⚠️ The `paymentData` object on a marketplace seller order is not a VTEX Gateway transaction. Filling that object does not create a Get transaction result on the seller account. See [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).
+> ⚠️ The `paymentData` object on a marketplace seller order isn't a VTEX Gateway transaction. Don't expect the Get transaction endpoint on the seller account to return a transaction only because `paymentData` is present. See [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).

--- a/readme-api-md/Payments Gateway API/payments-gateway-api-overview.md
+++ b/readme-api-md/Payments Gateway API/payments-gateway-api-overview.md
@@ -13,3 +13,5 @@ updatedAt: "2022-06-15T19:38:22.663Z"
 }
 [/block]
 The Payments Gateway API allows you to get payment data and process your store's transactions.
+
+> ⚠️ The `paymentData` object on a marketplace seller order is not a VTEX Gateway transaction. Filling that object does not create a Get transaction result on the seller account. See [Marketplace payment data on seller orders](https://developers.vtex.com/docs/guides/marketplace-payment-data-on-seller-orders).


### PR DESCRIPTION
### Summary

Adds a Payments guide for native `paymentData` on marketplace seller orders: fiscal NT 2025.001 fields in `connectorResponses` (`acquirerCnpj`, `authId`), `PAYMENT-FROM-AFFILIATE` as the assumed-payment signal, and a warning that this is not a seller Gateway transaction.

Related: EDU-19476

---

### Type of change

* [x] **New content** — Adds new documentation.
* [x] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [x] The content follows the VTEX Style Guide.
* [x] Markdown renders correctly (headings, lists, tables, callouts).
* [x] Links, images, code blocks, and examples are valid.
* [x] Terminology, product names, and API references are consistent.
* [x] Frontmatter (title, description, tags, slug) is correct
* [x] Files follow the expected folder structure and naming conventions.

---

### Test plan

- [ ] New guide appears under Payments > Marketplace in the category page.
- [ ] Payload matches the Payments-approved contract (`connectorResponses.acquirerCnpj` and `authId`).
- [ ] External seller processing payments no longer says no development is needed from the seller.
- [ ] Payments Gateway API overview warns that Get transaction does not appear on the seller account only because `paymentData` is filled.


Made with [Cursor](https://cursor.com)