### PR TITLE
docs: add GET routes for retrieving B2B users

### DIFF
--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -107,69 +107,6 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
 }
 ```
 
-## Retrieving created users
-
-After creating a user, you can retrieve their `userId` and identifiers using either of the following endpoints.
-
-### Get user by ID
-
-Retrieves a user by their `userId`.
-
->ℹ️ For more information, see `GET` [Get user by ID](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/-userId-).
-
-#### Request example
-
-```shell
-curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/{{userId}}" \
-  -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
-  -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
-```
-
-#### Response example
-
-```json
-{
-  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
-  "identifiers": [
-    { "type": "email", "value": "user_test@acme.com" },
-    { "type": "username", "value": "user_test" },
-    { "type": "phoneNumber", "value": "00123456789" }
-  ]
-}
-```
-
-### Get user by identifier
-
-Retrieves a user by one of their identifiers.
-
-**Query parameters:**
-
-* `identifier`: The value of the identifier (e.g., an email address, username, or phone number).
-* `type`: The type of identifier. Supported values are `username`, `email`, `phonenumber`, and `apikey`.
-
->ℹ️ For more information, see `GET` [Get user by identifier](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/info).
-
-#### Request example
-
-```shell
-curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=user_test@acme.com&type=email" \
-  -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
-  -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
-```
-
-#### Response example
-
-```json
-{
-  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
-  "identifiers": [
-    { "type": "email", "value": "user_test@acme.com" },
-    { "type": "username", "value": "user_test" },
-    { "type": "phoneNumber", "value": "00123456789" }
-  ]
-}
-```
-
 ## Step 2 - Create organizational unit
 
 >⚠️ This step is required only if the storefront user's organizational unit does not exist yet. If it already exists, proceed to [Step 3 - Assign user to organizational unit](#step-3---assign-user-to-organizational-unit).
@@ -333,6 +270,69 @@ curl -X POST "https://{{accountName}}.vtexcommercestable.com.br/api/dataentities
   "Id": "shopper-cbfc4f67-6ea3-11ee-83ab-0a8d18f9f827",
   "Href": "http://{{accountName}}.vtexcommercestable.com.br/api/dataentities/shopper/documents/cbfc4f67-6ea3-11ee-83ab-0a8d18f9f827",
   "DocumentId": "cbfc4f67-6ea3-11ee-83ab-0a8d18f9f827"
+}
+```
+
+## Retrieving created users
+
+After creating a user, you can retrieve their `userId` and identifiers using either of the following endpoints.
+
+### Get user by ID
+
+Retrieves a user by their `userId`.
+
+>ℹ️ For more information, see `GET` [Get user by ID](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/-userId-).
+
+#### Request example
+
+```shell
+curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/{{userId}}" \
+  -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
+  -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
+```
+
+#### Response example
+
+```json
+{
+  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+  "identifiers": [
+    { "type": "email", "value": "user_test@acme.com" },
+    { "type": "username", "value": "user_test" },
+    { "type": "phoneNumber", "value": "00123456789" }
+  ]
+}
+```
+
+### Get user by identifier
+
+Retrieves a user by one of their identifiers.
+
+**Query parameters:**
+
+* `identifier`: The value of the identifier (e.g., an email address, username, or phone number).
+* `type`: The type of identifier. Supported values are `username`, `email`, `phonenumber`, and `apikey`.
+
+>ℹ️ For more information, see `GET` [Get user by identifier](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/info).
+
+#### Request example
+
+```shell
+curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=user_test@acme.com&type=email" \
+  -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
+  -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
+```
+
+#### Response example
+
+```json
+{
+  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+  "identifiers": [
+    { "type": "email", "value": "user_test@acme.com" },
+    { "type": "username", "value": "user_test" },
+    { "type": "phoneNumber", "value": "00123456789" }
+  ]
 }
 ```
 

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -92,7 +92,7 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
     },
     {
         "type": "phoneNumber",
-        "value": "415‑602‑8838"
+        "value": "415-602-8838"
     }
   ]
 }'
@@ -253,10 +253,10 @@ curl -X POST "https://{{accountName}}.vtexcommercestable.com.br/api/dataentities
   -H "Accept: application/json" \
   -d '{
     "userId": "{{userId}}",
-    "firstName": "User First Name",
-    "lastName": "User Last Name",
+    "firstName": "John",
+    "lastName": "Doe",
     "document": "111.444.000-00",
-    "email": "user@vtex.com",
+    "email": "john.doe@acme.com",
     "phone": "5583987499600",
     "documentType": "cpf",
     "cards": []
@@ -295,11 +295,11 @@ curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator
 
 ```json
 {
-  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+  "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
   "identifiers": [
-    { "type": "email", "value": "user_test@acme.com" },
-    { "type": "username", "value": "user_test" },
-    { "type": "phoneNumber", "value": "00123456789" }
+    { "type": "email", "value": "john.doe@gmail.com" },
+    { "type": "username", "value": "john_doe" },
+    { "type": "phoneNumber", "value": "415-602-8838" }
   ]
 }
 ```
@@ -318,7 +318,7 @@ Retrieves a user by one of their identifiers.
 #### Request example
 
 ```shell
-curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=user_test@acme.com&type=email" \
+curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=john.doe@gmail.com&type=email" \
   -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
   -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
 ```
@@ -327,11 +327,11 @@ curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator
 
 ```json
 {
-  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+  "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
   "identifiers": [
-    { "type": "email", "value": "user_test@acme.com" },
-    { "type": "username", "value": "user_test" },
-    { "type": "phoneNumber", "value": "00123456789" }
+    { "type": "email", "value": "john.doe@gmail.com" },
+    { "type": "username", "value": "john_doe" },
+    { "type": "phoneNumber", "value": "415-602-8838" }
   ]
 }
 ```

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -83,15 +83,15 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
   -d '{
   "identifiers": [
     {
-        "type": "username", 
+        "type": "username",
         "value": "beneson_test_21"
-    }, 
+    },
     {
-        "type": "email", 
+        "type": "email",
         "value": "beneson2010@gmail.com+4"
-    }, 
+    },
     {
-        "type": "phoneNumber", 
+        "type": "phoneNumber",
         "value": "415‑602‑8838"
     }
   ]

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -88,7 +88,7 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
     },
     {
         "type": "email",
-        "value": "john.doe@gmail.com"
+        "value": "john.doe@acme.com"
     },
     {
         "type": "phoneNumber",
@@ -256,7 +256,7 @@ curl -X POST "https://{{accountName}}.vtexcommercestable.com.br/api/dataentities
     "firstName": "John",
     "lastName": "Doe",
     "document": "111.444.000-00",
-    "email": "john.doe@acme.com",
+    "email": "buyer.john.doe@acme.com",
     "phone": "5583987499600",
     "documentType": "cpf",
     "cards": []
@@ -297,7 +297,7 @@ curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator
 {
   "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
   "identifiers": [
-    { "type": "email", "value": "john.doe@gmail.com" },
+    { "type": "email", "value": "john.doe@acme.com" },
     { "type": "username", "value": "john_doe" },
     { "type": "phoneNumber", "value": "415-602-8838" }
   ]
@@ -318,7 +318,7 @@ Retrieves a user by one of their identifiers.
 #### Request example
 
 ```shell
-curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=john.doe@gmail.com&type=email" \
+curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=john.doe@acme.com&type=email" \
   -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
   -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
 ```
@@ -329,7 +329,7 @@ curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator
 {
   "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
   "identifiers": [
-    { "type": "email", "value": "john.doe@gmail.com" },
+    { "type": "email", "value": "john.doe@acme.com" },
     { "type": "username", "value": "john_doe" },
     { "type": "phoneNumber", "value": "415-602-8838" }
   ]

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -84,11 +84,11 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
   "identifiers": [
     {
         "type": "username",
-        "value": "beneson_test_21"
+        "value": "john_doe"
     },
     {
         "type": "email",
-        "value": "beneson2010@gmail.com+4"
+        "value": "john.doe@gmail.com"
     },
     {
         "type": "phoneNumber",
@@ -103,7 +103,7 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
 ```json
 {
   "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
-  "identifier": "beneson_test_21"
+  "identifier": "john_doe"
 }
 ```
 

--- a/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
+++ b/docs/guides/b2b/b2b-buyer-portal/b2b-user-provisioning.md
@@ -27,6 +27,7 @@ Before provisioning B2B users in VTEX, make sure the required features are enabl
 | Product | Category | Resource | Associated endpoints |
 | :---- | :---- | :---- | :---- |
 | Authenticator | User Management | Create User | `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/authenticator-api#post-/api/authenticator/v1/storefront/users) |
+| Authenticator | User Management | Read Users | `GET` [Get user by ID](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/-userId-) <br/><br/>`GET` [Get user by identifier](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/info) |
 | Organization Units | Units | Edit Organization Unit | `POST` [Create organizational unit](https://developers.vtex.com/docs/api-reference/organization-units-api#post-/api/organization-units/v1) <br/><br/>`POST` [Assign user to organizational unit](https://developers.vtex.com/docs/api-reference/organization-units-api#post-/api/vtexid/organization-units/-organizationUnitId-/users) |
 | License Manager | Services access control | Edit Storefront User Permissions | `POST` [Assign storefront roles to user](https://developers.vtex.com/docs/api-reference/storefront-permissions-api#post-/api/license-manager/storefront/users) |
 | Dynamic Storage | Dynamic storage generic resources | Insert or update document (not remove) | `POST` [Create buyer](https://developers.vtex.com/docs/api-reference/b2b-buyer-data-api#post-/api/dataentities/shopper/documents) |
@@ -103,6 +104,69 @@ curl -X POST "https://{{accountname}}.vtexcommercestable.com.br/api/authenticato
 {
   "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
   "identifier": "beneson_test_21"
+}
+```
+
+## Retrieving created users
+
+After creating a user, you can retrieve their `userId` and identifiers using either of the following endpoints.
+
+### Get user by ID
+
+Retrieves a user by their `userId`.
+
+>ℹ️ For more information, see `GET` [Get user by ID](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/-userId-).
+
+#### Request example
+
+```shell
+curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/{{userId}}" \
+  -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
+  -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
+```
+
+#### Response example
+
+```json
+{
+  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+  "identifiers": [
+    { "type": "email", "value": "user_test@acme.com" },
+    { "type": "username", "value": "user_test" },
+    { "type": "phoneNumber", "value": "00123456789" }
+  ]
+}
+```
+
+### Get user by identifier
+
+Retrieves a user by one of their identifiers.
+
+**Query parameters:**
+
+* `identifier`: The value of the identifier (e.g., an email address, username, or phone number).
+* `type`: The type of identifier. Supported values are `username`, `email`, `phonenumber`, and `apikey`.
+
+>ℹ️ For more information, see `GET` [Get user by identifier](https://developers.vtex.com/docs/api-reference/authenticator-api#get-/api/authenticator/v1/users/info).
+
+#### Request example
+
+```shell
+curl -X GET "https://{{accountName}}.vtexcommercestable.com.br/api/authenticator/v1/users/info?identifier=user_test@acme.com&type=email" \
+  -H "X-VTEX-API-AppKey: {{X-VTEX-API-AppKey}}" \
+  -H "X-VTEX-API-AppToken: {{X-VTEX-API-AppToken}}"
+```
+
+#### Response example
+
+```json
+{
+  "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+  "identifiers": [
+    { "type": "email", "value": "user_test@acme.com" },
+    { "type": "username", "value": "user_test" },
+    { "type": "phoneNumber", "value": "00123456789" }
+  ]
 }
 ```
 
@@ -276,7 +340,6 @@ curl -X POST "https://{{accountName}}.vtexcommercestable.com.br/api/dataentities
 
 For additional user and organizational management operations, see the following API references:
 
-* `GET` [Get user by identifier](https://developers.vtex.com/docs/api-reference/vtex-id-api#get-/api/vtexid/pvt/user/info)
 * `GET` [Get organizational units](https://developers.vtex.com/docs/api-reference/organization-units-api#get-/api/organization-units/v1)
 * `GET` [Get users from organizational unit](https://developers.vtex.com/docs/api-reference/organization-units-api#get-/api/vtexid/organization-units/-organizationUnitId-/users)
 * `GET` [Verify user roles](https://developers.vtex.com/docs/api-reference/storefront-permissions-api#get-/api/license-manager/storefront/users/-userId-/roles)


### PR DESCRIPTION
## Summary
- Adds a "Retrieving created users" section at the end of the B2B user provisioning guide, documenting the new `authenticator-api` GET routes (get user by `userId` and get user by identifier) that are being documented in parallel in the API reference.
- Adds the corresponding `Authenticator > User Management > Read Users` permission row to the "Before you begin" table.
- Removes the now-superseded `vtex-id-api` "Get user by identifier" bullet from "Additional operations".
- Standardizes all request/response examples in the guide around a single, generic persona (`john_doe` / `john.doe@acme.com` / userId `f0a15a42-f7fc-4b09-a9ab-fabc76d9f332`), replacing the previous mixed sample data.
- Minor cleanup: removes trailing whitespace in the Step 1 request example.

Depends on https://github.com/vtex/openapi-schemas/pull/1777

## Test plan
- [ ] Confirm the new `authenticator-api` anchors (`#get-/api/authenticator/v1/users/-userId-`, `#get-/api/authenticator/v1/users/info`) resolve once that API reference page is published.